### PR TITLE
Add handler for 'stalled' event

### DIFF
--- a/web/hls.ts
+++ b/web/hls.ts
@@ -97,6 +97,10 @@ export function makeLivestream(readyFn: (isReady: boolean) => void) {
         videoEl.addEventListener('error', (e) => {
             onNetworkError();
         });
+
+        videoEl.addEventListener('stalled', (e) => {
+            onNetworkError();
+        });
     }
     loadHlsMedia(videoUrl);
 }


### PR DESCRIPTION
to reset page status when stream ends on iOS