### PR TITLE
Order auditorium spaces alphabetically by ID within their parent space

### DIFF
--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -322,7 +322,7 @@ export class Conference {
             isPublic: true,
             name: makeDisplayName(auditorium.name, auditorium.id),
         });
-        await parentSpace.addChildSpace(audSpace);
+        await parentSpace.addChildSpace(audSpace, { order: `auditorium-${auditorium.id}` });
 
         const roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(AUDITORIUM_CREATION_TEMPLATE, {
             creation_content: {


### PR DESCRIPTION
This change will allow new auditoriums to be added late, while
maintaining alphabetical order for the listing of auditoriums.

Part of #15.