### PR TITLE
Show countdown to Q&A on the scoreboard

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -323,6 +323,8 @@ export class Scheduler {
         } else if (task.type === ScheduledTaskType.TalkQA5M) {
             if (!task.talk.prerecorded) return;
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your Q&A starts in about 5 minutes</h3><p>The upvoted questions appear in the "Upvoted messages" widget next to the Jitsi conference. Prepare your answers!</p>`);
+            const qaStartTime = task.talk.qa_start_datetime + (config.conference.database.scheduleBufferSeconds * 1000);
+            await this.scoreboard.showQACountdown(confAud.roomId, qaStartTime);
         } else if (task.type === ScheduledTaskType.TalkEnd5M) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk ends in about 5 minutes</h3><p>The next talk will start automatically after yours. In 5 minutes, this room will be opened up for anyone to join. They will not be able to see history.</p>`);
             await this.client.sendHtmlText(confAud.roomId, `<h3>This talk ends in about 5 minutes</h3><p>Ask questions here for the speakers!</p>`);

--- a/src/web.ts
+++ b/src/web.ts
@@ -190,6 +190,7 @@ export function renderScoreboard(req: Request, res: Response, scoreboard: Scoreb
     const auditorium = config.RUNTIME.conference.storedAuditoriums.find(a => a.roomId === roomId);
     if (!auditorium) return res.sendStatus(404);
 
-    const sb = scoreboard.getScoreboard(auditorium.roomId);
-    res.send(sb || {ordered: []});
+    let sb = scoreboard.getScoreboard(auditorium.roomId);
+    sb = sb || {qaStartTime: null, ordered: []};
+    res.send(sb);
 }

--- a/web/common.scss
+++ b/web/common.scss
@@ -88,15 +88,20 @@ html, body {
   right: 0;
 }
 
-#liveBanner {
+.banner {
   display: none; /* changed later */
   text-align: center;
   position: absolute;
   top: 0;
   left: 0;
-  width: 375px;
+  width: 100%;
   background-color: tomato;
   padding: 2px;
+  box-sizing: border-box; /* the padding must go inside the 100% width, not outside */
+}
+
+#liveBanner {
+  width: 375px;
   border-bottom-right-radius: 8px;
 }
 

--- a/web/scoreboard.liquid
+++ b/web/scoreboard.liquid
@@ -8,6 +8,7 @@
 </head>
 <body id="scoreboard">
     <noscript>Sorry, you'll need JavaScript to use this widget.</noscript>
+    <div id="scoreboardQABanner" class="banner"></div>
     <h3>Scoreboard for <a href="https://matrix.to/#/{{trackingAlias}}" onclick="intercept(event)">{{trackingAlias}}</a></h3>
     <p>The most upvoted messages will appear here.</p>
     <div id="upvoted"></div>

--- a/web/scoreboard.ts
+++ b/web/scoreboard.ts
@@ -64,7 +64,8 @@ let bannerUpdateTimer: number | null = null;
 
 function render(scoreboard: Scoreboard) {
     // Update countdown banner
-    if (scoreboard.qaStartTime != null) {
+    if (scoreboard.qaStartTime !== null) {
+        // Show the countdown banner
         function renderBannerText(qaStartTime: number) {
             const timeUntilStart = qaStartTime - Date.now();
             const banner = document.getElementById('scoreboardQABanner');
@@ -83,6 +84,7 @@ function render(scoreboard: Scoreboard) {
         renderBannerText(scoreboard.qaStartTime);
         document.getElementById('scoreboardQABanner').style.display = 'block';
     } else {
+        // Hide the countdown banner
         clearInterval(bannerUpdateTimer);
         bannerUpdateTimer = null;
         document.getElementById('scoreboardQABanner').style.display = 'none';

--- a/web/talk.liquid
+++ b/web/talk.liquid
@@ -20,7 +20,7 @@
     </div>
     <div id="jitsiUnderlay"><h3>Connecting to conference...</h3></div>
     <div id="jitsiContainer"></div>
-    <div id="liveBanner"><span><!-- Populated with media queries --></span></div>
+    <div id="liveBanner" class="banner"><span><!-- Populated with media queries --></span></div>
     <script src="https://{{conferenceDomain}}/libs/external_api.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Show a 5 minute countdown to Q&A on the scoreboard. Once Q&A starts,
the countdown text is replaced with a message telling speakers that
Q&A is ongoing.

The new countdown is only shown for pre-recorded talks, since live
talks are presumed to start off live already.

Resolves #12.

---------------------------------

Currently looks like:
![image](https://user-images.githubusercontent.com/8349537/149410328-960b672a-d9cb-4ab1-b552-e1799d674cb7.png)
