### PR TITLE
Make talk room's live banner more accurate and add countdown

### DIFF
--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -54,6 +54,7 @@ import { PentaDb } from "./db/PentaDb";
 import { PermissionsCommand } from "./commands/PermissionsCommand";
 import { InterestRoom } from "./models/InterestRoom";
 import { IStateEvent } from "./models/room_state";
+import { IDbTalk } from "./db/DbTalk";
 
 export class Conference {
     private dbRoom: MatrixRoom;
@@ -534,6 +535,15 @@ export class Conference {
 
     public getTalk(talkId: string): Talk {
         return this.talks[talkId];
+    }
+
+    /**
+     * Gets the Pentabarf database record for a talk.
+     * @param talkId The talk ID.
+     * @returns The database record for the talk, if it exists; `null` otherwise.
+     */
+    public async getDbTalk(talkId: string): Promise<IDbTalk | null> {
+        return this.pentaDb.getTalk(talkId);
     }
 
     public getInterestRoom(intId: string): InterestRoom {

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -90,9 +90,9 @@ export function getStartTime(task: ITask): number {
         case ScheduledTaskType.TalkEnd:
             return task.talk.end_datetime;
         case ScheduledTaskType.TalkQA5M:
-            return (task.talk.qa_start_datetime + (config.conference.database.scheduleBufferSeconds * 1000)) - (5 * 60 * 1000);
+            return task.talk.qa_start_datetime - (5 * 60 * 1000);
         case ScheduledTaskType.TalkQA:
-            return task.talk.qa_start_datetime + (config.conference.database.scheduleBufferSeconds * 1000);
+            return task.talk.qa_start_datetime;
         default:
             throw new Error("Unknown task type for getStartTime(): " + task.type);
     }
@@ -354,8 +354,7 @@ export class Scheduler {
                 `<p>Remember that the broadcast feed is buffered and lags many seconds behind. ` +
                 `Do not wait for it to finish, otherwise you will create a long pause!</p>`,
             );
-            const qaStartTime = task.talk.qa_start_datetime + (config.conference.database.scheduleBufferSeconds * 1000);
-            await this.scoreboard.showQACountdown(confAud.roomId, qaStartTime);
+            await this.scoreboard.showQACountdown(confAud.roomId, task.talk.qa_start_datetime);
         } else if (task.type === ScheduledTaskType.TalkEnd5M) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk ends in about 5 minutes</h3><p>The next talk will start automatically after yours. In 5 minutes, this room will be opened up for anyone to join. They will not be able to see history.</p>`);
             await this.client.sendHtmlText(confAud.roomId, `<h3>This talk ends in about 5 minutes</h3><p>Ask questions here for the speakers!</p>`);

--- a/src/db/DbTalk.ts
+++ b/src/db/DbTalk.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export interface IDbTalk {
+export interface IRawDbTalk {
     event_id: string; // penta ID
     conference_room: string;
     start_datetime: number; // ms timestamp, utc
@@ -23,4 +23,14 @@ export interface IDbTalk {
     end_datetime: number; // ms timestamp, utc
     qa_start_datetime: number; // ms timestamp, utc
     prerecorded: boolean;
+}
+
+export interface IDbTalk extends IRawDbTalk {
+    /**
+     * The start time of the talk's livestream, as a Unix timestamp in milliseconds.
+     *
+     * This is the start of the Q&A session for prerecorded talks, and the start of the talk for
+     * non-prerecorded talks.
+     */
+    livestream_start_datetime: number; // ms timestamp, utc
 }

--- a/src/db/PentaDb.ts
+++ b/src/db/PentaDb.ts
@@ -113,7 +113,16 @@ export class PentaDb {
         const result = await this.client.query(
             `${SCHEDULE_SELECT} WHERE ${timeQuery} >= (${now} - MAKE_INTERVAL(mins => $2)) AND ${timeQuery} <= (${now} + MAKE_INTERVAL(mins => $3))`,
             [config.conference.timezone, minBefore, inNextMinutes]);
-        return result.rows;
+        return this.postprocessDbTalks(result.rows);
+    }
+
+    private postprocessDbTalk(talk: IDbTalk): IDbTalk {
+        talk.qa_start_datetime += config.conference.database.scheduleBufferSeconds * 1000;
+        return talk;
+    }
+
+    private postprocessDbTalks(rows: IDbTalk[]): IDbTalk[] {
+        return rows.map(this.postprocessDbTalk);
     }
 
     private sanitizeRecords(rows: IDbPerson[]): IDbPerson[] {

--- a/src/db/PentaDb.ts
+++ b/src/db/PentaDb.ts
@@ -108,6 +108,18 @@ export class PentaDb {
         return this.getTalksWithin(END_QUERY, inNextMinutes, minBefore);
     }
 
+    /**
+     * Gets the record for a talk.
+     * @param talkId The talk ID.
+     * @returns The record for the talk, if it exists; `null` otherwise.
+     */
+    public async getTalk(talkId: string): Promise<IDbTalk | null> {
+        const result = await this.client.query(
+            `${SCHEDULE_SELECT} WHERE event_id::text = $2`,
+            [config.conference.timezone, talkId]);
+        return result.rowCount > 0 ? this.postprocessDbTalk(result.rows[0]) : null;
+    }
+
     private async getTalksWithin(timeQuery: string, inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
         const now = "NOW() AT TIME ZONE 'UTC'";
         const result = await this.client.query(

--- a/src/web.ts
+++ b/src/web.ts
@@ -69,6 +69,11 @@ export async function renderTalkWidget(req: Request, res: Response) {
         return res.sendStatus(404);
     }
 
+    // TODO: Cache dbTalk so that the Pentabarf database isn't hit every time.
+    //       This endpoint is only used by speakers/hosts/coordinators,
+    //       so we don't expect too much load.
+    const dbTalk = await config.RUNTIME.conference.getDbTalk(talkId);
+
     const streamUrl = template(config.livestream.talkUrl, {
         audId: audId.toLowerCase(),
         slug: (await talk.getDefinition()).slug.toLowerCase(),
@@ -80,6 +85,8 @@ export async function renderTalkWidget(req: Request, res: Response) {
         roomName: await talk.getName(),
         conferenceDomain: config.livestream.jitsiDomain,
         conferenceId: base32.stringify(Buffer.from(talk.roomId), { pad: false }).toLowerCase(),
+        livestreamStartTime: dbTalk?.livestream_start_datetime ?? "",
+        livestreamEndTime: dbTalk?.end_datetime ?? "",
     });
 }
 

--- a/web/common.scss
+++ b/web/common.scss
@@ -105,8 +105,12 @@ html, body {
   border-bottom-right-radius: 8px;
 }
 
-#liveBanner > span::after {
-  content: 'You are being live broadcasted';
+#liveBanner #liveBannerShortText {
+  display: none;
+}
+
+#liveBanner #liveBannerLongText {
+  display: inline;
 }
 
 @media only screen and (max-width: 600px) {
@@ -114,8 +118,12 @@ html, body {
     width: 75px;
   }
 
-  #liveBanner > span::after {
-    content: 'LIVE';
+  #liveBanner #liveBannerShortText {
+    display: inline;
+  }
+
+  #liveBanner #liveBannerLongText {
+    display: none;
   }
 }
 

--- a/web/common.ts
+++ b/web/common.ts
@@ -14,6 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/**
+ * Converts a duration to a string.
+ * @param duration The duration, in milliseconds.
+ * @returns The duration, in mm:ss format.
+ */
+export function formatDuration(duration: number): string {
+    const minutes = Math.floor(duration / 60 / 1000).toString().padStart(2, "0");
+    const seconds = (Math.floor(duration / 1000) % 60).toString().padStart(2, "0");
+    return `${minutes}:${seconds}`;
+}
+
 export function getAttr(name: string): string {
     return Array.from(document.getElementsByTagName('meta'))
         .find(t => t.name === name)

--- a/web/scoreboard.ts
+++ b/web/scoreboard.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import "./common.scss";
 import { MatrixCapabilities, WidgetApi } from "matrix-widget-api";
 import { widgetId } from "./widgets";
-import { getAttr } from "./common";
+import { formatDuration, getAttr } from "./common";
 
 const upvoteEl = document.getElementById("upvoted");
 
@@ -72,9 +72,7 @@ function render(scoreboard: Scoreboard) {
             if (timeUntilStart < 0) {
                 banner.innerText = "Q&A has started";
             } else {
-                const minutes = Math.floor(timeUntilStart / 60 / 1000).toString().padStart(2, "0");
-                const seconds = (Math.floor(timeUntilStart / 1000) % 60).toString().padStart(2, "0");
-                const text = `Q&A starts in ${minutes}:${seconds}`;
+                const text = `Q&A starts in ${formatDuration(timeUntilStart)}`;
                 if (banner.innerText !== text) {
                     banner.innerText = text;
                 }

--- a/web/talk.liquid
+++ b/web/talk.liquid
@@ -7,6 +7,8 @@
     <meta name="org.matrix.confbot.conf_domain" content="{{conferenceDomain}}" />
     <meta name="org.matrix.confbot.conf_id" content="{{conferenceId}}" />
     <meta name="org.matrix.confbot.conf_name" content="{{roomName}}" />
+    <meta name="org.matrix.confbot.livestream_start_time" content="{{livestreamStartTime}}" />
+    <meta name="org.matrix.confbot.livestream_end_time" content="{{livestreamEndTime}}" />
 </head>
 <body>
     <noscript>Sorry, you'll need JavaScript to use this widget.</noscript>

--- a/web/talk.liquid
+++ b/web/talk.liquid
@@ -22,7 +22,10 @@
     </div>
     <div id="jitsiUnderlay"><h3>Connecting to conference...</h3></div>
     <div id="jitsiContainer"></div>
-    <div id="liveBanner" class="banner"><span><!-- Populated with media queries --></span></div>
+    <div id="liveBanner" class="banner">
+        <span id="liveBannerShortText">LIVE</span>
+        <span id="liveBannerLongText">You are being live broadcasted</span>
+    </div>
     <script src="https://{{conferenceDomain}}/libs/external_api.min.js"></script>
 </body>
 </html>

--- a/web/talk.ts
+++ b/web/talk.ts
@@ -112,6 +112,20 @@ joinButton.addEventListener('click', () => {
     joinConference(jitsiOpts, widgetApi, () => onJitsiEnd());
 });
 
+let liveBannerVisible: boolean = false;
+/**
+ * Shows or hides the live banner.
+ * @param visible `true` to show the live banner; `false` to hide it.
+ */
+function setLiveBannerVisible(visible: boolean) {
+    if (liveBannerVisible === visible) {
+        return;
+    }
+
+    liveBannerVisible = visible;
+    liveBanner.style.display = visible ? 'block' : 'none';
+}
+
 /**
  * Updates the livestream banner.
  * @returns The interval until the next update, in milliseconds.
@@ -119,7 +133,7 @@ joinButton.addEventListener('click', () => {
 function updateLivestreamBanner(): number | null {
     if (livestreamStartTime == null || livestreamEndTime == null) {
         // Livestream start and end time are unavailable.
-        liveBanner.style.display = 'none';
+        setLiveBannerVisible(false);
         return null;
     }
 
@@ -127,7 +141,7 @@ function updateLivestreamBanner(): number | null {
     if (now < livestreamStartTime - 5 * 60 * 1000) {
         // The start of the livestream is more than 5 minutes in the future.
         // Don't show anything.
-        liveBanner.style.display = 'none';
+        setLiveBannerVisible(false);
         return livestreamStartTime - 5 * 60 * 1000 - now;
     } else if (now < livestreamStartTime) {
         // The livestream starts within 5 minutes.
@@ -150,7 +164,7 @@ function updateLivestreamBanner(): number | null {
         if (liveBannerLongText.innerText !== longText) {
             liveBannerLongText.innerText = longText;
         }
-        liveBanner.style.display = 'block';
+        setLiveBannerVisible(true);
         return 100;
     } else if (now < livestreamEndTime) {
         // The livestream is ongoing.
@@ -161,11 +175,11 @@ function updateLivestreamBanner(): number | null {
             liveBannerShortText.innerText = "LIVE";
             liveBannerLongText.innerText = "You are being live broadcasted";
         }
-        liveBanner.style.display = 'block';
+        setLiveBannerVisible(true);
         return livestreamEndTime - now;
     } else {
         // The livestream has ended.
-        liveBanner.style.display = 'none';
+        setLiveBannerVisible(false);
         return null;
     }
 }


### PR DESCRIPTION
This changes the behaviour of the live banner in the talk room. Now it
will be only be shown while the livestream is ongoing, or starting in
less than 5 minutes. In addition, it will be shown both in and out of
the Jitsi room.

The livestream is assumed to start at Q&A time for prerecorded talks
and at the start of the talk for non-prerecorded talks.

The live banner will not be shown while the Jitsi call is in fullscreen
mode, since Jitsi does not allow us to customise it that way.

Closes #44.

--------------------------------------------------------------------------------

### >5 minutes before start
No banner shown.

### 5 minutes before start

The banner cannot be shown in fullscreen mode, unless we create our own buttons to enter and exit fullscreen.

![image](https://user-images.githubusercontent.com/8349537/149782441-6aaa33e0-0cdf-40e7-9f45-edd786d7f8eb.png)

![image](https://user-images.githubusercontent.com/8349537/149782561-bcdd4e15-94ed-4cac-a492-bc00aa24c4d7.png)

![image](https://user-images.githubusercontent.com/8349537/149782671-8814ad4c-0d2c-43c2-be67-d770a33be04c.png)

### During Q&A (prerecorded) / talk (non-prerecorded)

The banner cannot be shown in fullscreen mode, unless we create our own buttons to enter and exit fullscreen.

![image](https://user-images.githubusercontent.com/8349537/149784470-1ab53376-5a60-4177-985f-c9f5145628ec.png)

![image](https://user-images.githubusercontent.com/8349537/149784023-ce77caf7-7bc6-4277-84f8-6b49a86e5649.png)

![image](https://user-images.githubusercontent.com/8349537/149784669-418d6240-d0fe-48fa-80ab-edbbb3c62f32.png)

### After talk
No banner shown.