### PR TITLE
Add support for reusing existing rooms as interest rooms

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -245,6 +245,10 @@ conference:
     displayNameSuffixes:
       #"S.": " stand"
 
+  # A mapping of pre-existing rooms to re-use as interest rooms.
+  existingInterestRooms:
+    #"I.infodesk": "#infodesk:example.org"
+
   # The subspaces to create under the main conference space
   subspaces:
     #stands:

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -203,6 +203,24 @@ export class Conference {
             await Promise.all(tasks);
         }
 
+        // Resolve pre-existing interest rooms
+        for (const interestId in config.conference.existingInterestRooms) {
+            if (interestId in this.interestRooms) {
+                continue;
+            }
+
+            const roomIdOrAlias = config.conference.existingInterestRooms[interestId];
+            let roomId: string;
+            try {
+                roomId = await this.client.resolveRoom(roomIdOrAlias);
+            } catch (e) {
+                // The room probably doesn't exist yet.
+                continue;
+            }
+
+            this.interestRooms[interestId] = new InterestRoom(roomId, this.client, this, interestId);
+        }
+
         // Locate other metadata in the room
         if (!this.dbRoom) return;
         const dbState = (await this.client.getRoomState(this.dbRoom.roomId)).filter(s => !!s.content);
@@ -313,27 +331,48 @@ export class Conference {
     }
 
     public async createInterestRoom(interestRoom: IInterestRoom): Promise<InterestRoom> {
-        if (this.interestRooms[interestRoom.id]) {
-            return this.interestRooms[interestRoom.id];
+        const parentSpace = await this.getDesiredParentSpace(interestRoom);
+
+        // Resolve pre-existing rooms that were created after the bot started up.
+        if (!this.interestRooms[interestRoom.id] &&
+            interestRoom.id in config.conference.existingInterestRooms) {
+            const roomIdOrAlias = config.conference.existingInterestRooms[interestRoom.id];
+            const roomId = await this.client.resolveRoom(roomIdOrAlias);
+            this.interestRooms[interestRoom.id] = new InterestRoom(
+                roomId, this.client, this, interestRoom.id
+            );
         }
 
-        const parentSpace = await this.getDesiredParentSpace(interestRoom);
-        const roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(SPECIAL_INTEREST_CREATION_TEMPLATE, {
-            creation_content: {
-                [RSC_CONFERENCE_ID]: this.id,
-                [RSC_SPECIAL_INTEREST_ID]: interestRoom.id,
-            },
-            initial_state: [
-                makeStoredInterestRoom(this.id, interestRoom),
-                makeParentRoom(this.dbRoom.roomId),
-            ],
-        }));
-        await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + interestRoom.name, interestRoom.id);
-        await this.dbRoom.addDirectChild(roomId);
-        this.interestRooms[interestRoom.id] = new InterestRoom(
-            roomId, this.client, this, interestRoom.id
-        );
-        await parentSpace.addChildRoom(roomId, { order: `interest-${interestRoom.id}` });
+        if (!this.interestRooms[interestRoom.id]) {
+            // Create a new interest room.
+            const roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(SPECIAL_INTEREST_CREATION_TEMPLATE, {
+                creation_content: {
+                    [RSC_CONFERENCE_ID]: this.id,
+                    [RSC_SPECIAL_INTEREST_ID]: interestRoom.id,
+                },
+                initial_state: [
+                    makeStoredInterestRoom(this.id, interestRoom),
+                    makeParentRoom(this.dbRoom.roomId),
+                ],
+            }));
+            await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + interestRoom.name, interestRoom.id);
+            await this.dbRoom.addDirectChild(roomId);
+            this.interestRooms[interestRoom.id] = new InterestRoom(
+                roomId, this.client, this, interestRoom.id
+            );
+            await parentSpace.addChildRoom(roomId, { order: `interest-${interestRoom.id}` });
+        } else {
+            // The interest room already exists, either because the conference has already been
+            // built, or a pre-existing room is being reused as an interest room.
+            const roomId = this.interestRooms[interestRoom.id].roomId;
+            // Put the room in the correct space.
+            if (!(roomId in await parentSpace.getChildEntities())) {
+                await parentSpace.addChildRoom(roomId, { order: `interest-${interestRoom.id}` });
+            }
+            
+            // In the future we may want to ensure that aliases are set in accordance with the
+            // config.
+        }
 
         return this.interestRooms[interestRoom.id];
     }

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -192,7 +192,7 @@ export class Conference {
                                 this.talks[createEvent[RSC_TALK_ID]] = new Talk(roomId, this.client, this);
                                 break;
                             case RoomKind.SpecialInterest:
-                                this.interestRooms[createEvent[RSC_SPECIAL_INTEREST_ID]] = new InterestRoom(roomId, this.client, this);
+                                this.interestRooms[createEvent[RSC_SPECIAL_INTEREST_ID]] = new InterestRoom(roomId, this.client, this, createEvent[RSC_SPECIAL_INTEREST_ID]);
                                 break;
                             default:
                                 break;
@@ -330,7 +330,9 @@ export class Conference {
         }));
         await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + interestRoom.name, interestRoom.id);
         await this.dbRoom.addDirectChild(roomId);
-        this.interestRooms[interestRoom.id] = new InterestRoom(roomId, this.client, this);
+        this.interestRooms[interestRoom.id] = new InterestRoom(
+            roomId, this.client, this, interestRoom.id
+        );
         await parentSpace.addChildRoom(roomId, { order: `interest-${interestRoom.id}` });
 
         return this.interestRooms[interestRoom.id];

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,9 @@ interface IConfig {
                 [auditoriumId: string]: string;
             };
         };
+        existingInterestRooms: {
+            [id: string]: string;
+        };
         subspaces: {
             [name: string]: {
                 displayName: string;

--- a/src/models/InterestRoom.ts
+++ b/src/models/InterestRoom.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import { MatrixClient } from "matrix-bot-sdk";
 import { Conference } from "../Conference";
 import { MatrixRoom } from "./MatrixRoom";
-import { RSC_SPECIAL_INTEREST_ID } from "./room_kinds";
 import { deprefix } from "../parsers/PentabarfParser";
 import { PhysicalRoom } from "./PhysicalRoom";
 
@@ -25,25 +24,18 @@ export class InterestRoom extends MatrixRoom implements PhysicalRoom {
     private id: string;
     private name: string;
 
-    constructor(roomId: string, client: MatrixClient, conference: Conference) {
+    constructor(roomId: string, client: MatrixClient, conference: Conference, id: string) {
         super(roomId, client, conference);
-    }
 
-    private async doFetch() {
-        if (this.id || this.name) return;
-
-        const createEvent = await this.client.getRoomStateEvent(this.roomId, "m.room.create", "");
-        this.id = createEvent[RSC_SPECIAL_INTEREST_ID];
-        this.name = deprefix(this.id).name;
+        this.id = id;
+        this.name = deprefix(id).name;
     }
 
     public async getName(): Promise<string> {
-        await this.doFetch();
         return this.name;
     }
 
     public async getId(): Promise<string> {
-        await this.doFetch();
         return this.id;
     }
 }

--- a/src/models/InterestRoom.ts
+++ b/src/models/InterestRoom.ts
@@ -20,6 +20,12 @@ import { MatrixRoom } from "./MatrixRoom";
 import { deprefix } from "../parsers/PentabarfParser";
 import { PhysicalRoom } from "./PhysicalRoom";
 
+/**
+ * Represents an interest room.
+ *
+ * Interest rooms may be new rooms created by the bot, or existing rooms created by another user.
+ * As such, they do not necessarily have any special state events.
+ */
 export class InterestRoom extends MatrixRoom implements PhysicalRoom {
     private id: string;
     private name: string;


### PR DESCRIPTION
Part of #74.

----------------------------------

This is mainly to support reusing the #infodesk room, while having the bot treat it the same as all the other special interest rooms.

In particular, the `!conference fdm` command expects a special interest room called `I.infodesk`:  
https://github.com/matrix-org/conference-bot/blob/beta.47/src/commands/FDMCommand.ts#L28