### PR TITLE
Only invite devroom coordinators to the coordinator support room

### DIFF
--- a/src/commands/InviteCommand.ts
+++ b/src/commands/InviteCommand.ts
@@ -58,6 +58,12 @@ export class InviteCommand implements ICommand {
         } else if (args[0] && args[0] === "coordinators-support") {
             let people: IDbPerson[] = [];
             for (const aud of conference.storedAuditoriums) {
+                if (!(await aud.getId()).startsWith("D.")) {
+                    // HACK: Only invite coordinators for D.* auditoriums.
+                    // TODO: Make invitations for support rooms more configurable.
+                    continue;
+                }
+
                 const inviteTargets = await conference.getInviteTargetsForAuditorium(aud, true);
                 people.push(...inviteTargets.filter(i => i.event_role === Role.Coordinator));
             }


### PR DESCRIPTION
An unpleasant hack to limit invitations to the coordinator support room to FOSDEM devroom coordinators.

A better solution would be to implement #76.