### PR TITLE
Prevent interest room moderators from modifying widgets

### DIFF
--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -368,6 +368,7 @@ export class Conference {
 
         // Ensure that widget modification is restricted to admins.
         const powerLevels = await this.client.getRoomStateEvent(roomId, "m.room.power_levels", "");
+        powerLevels.events ||= {};
         powerLevels.events["im.vector.modular.widgets"] = 100;
         await this.client.sendStateEvent(roomId, "m.room.power_levels", "", powerLevels);
 

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -367,6 +367,7 @@ export class Conference {
         }
 
         // Ensure that widget modification is restricted to admins.
+        // TODO: Handle missing or malformed `m.room.power_levels` events from pre-existing rooms.
         const powerLevels = await this.client.getRoomStateEvent(roomId, "m.room.power_levels", "");
         powerLevels.events ||= {};
         powerLevels.events["im.vector.modular.widgets"] = 100;

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -366,6 +366,11 @@ export class Conference {
             roomId = this.interestRooms[interestRoom.id].roomId;
         }
 
+        // Ensure that widget modification is restricted to admins.
+        const powerLevels = await this.client.getRoomStateEvent(roomId, "m.room.power_levels", "");
+        powerLevels.events["im.vector.modular.widgets"] = 100;
+        await this.client.sendStateEvent(roomId, "m.room.power_levels", "", powerLevels);
+
         // Ensure that the room appears within the correct space.
         await this.dbRoom.addDirectChild(roomId);
         const parentSpace = await this.getDesiredParentSpace(interestRoom);

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -149,6 +149,7 @@ export const SPECIAL_INTEREST_CREATION_TEMPLATE = {
         ...PUBLIC_ROOM_POWER_LEVELS_TEMPLATE,
         events: {
             ...PUBLIC_ROOM_POWER_LEVELS_TEMPLATE['events'],
+            "im.vector.modular.widgets": 100, // don't allow moderators to modify widgets
             "m.room.power_levels": 50,
         },
     },

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -149,7 +149,6 @@ export const SPECIAL_INTEREST_CREATION_TEMPLATE = {
         ...PUBLIC_ROOM_POWER_LEVELS_TEMPLATE,
         events: {
             ...PUBLIC_ROOM_POWER_LEVELS_TEMPLATE['events'],
-            "im.vector.modular.widgets": 100, // don't allow moderators to modify widgets
             "m.room.power_levels": 50,
         },
     },


### PR DESCRIPTION
The moderators of interest rooms are not the conference hosts and are
liable to break things. Restrict widget modification in those rooms to
admins.