### PR TITLE
Add support for dark theme to widgets

### DIFF
--- a/src/models/LiveWidget.ts
+++ b/src/models/LiveWidget.ts
@@ -52,7 +52,7 @@ export class LiveWidget {
                 waitForIframeLoad: true,
                 name: "Livestream",
                 avatar_url: config.livestream.widgetAvatar,
-                url: config.webserver.publicBaseUrl + "/widgets/auditorium.html?widgetId=$matrix_widget_id&auditoriumId=$auditoriumId",
+                url: config.webserver.publicBaseUrl + "/widgets/auditorium.html?widgetId=$matrix_widget_id&auditoriumId=$auditoriumId&theme=$theme",
                 data: {
                     title: await aud.getName(),
                     auditoriumId: await aud.getId(),
@@ -73,7 +73,7 @@ export class LiveWidget {
                 waitForIframeLoad: true,
                 name: "Livestream / Q&A",
                 avatar_url: config.livestream.widgetAvatar,
-                url: config.webserver.publicBaseUrl + "/widgets/talk.html?widgetId=$matrix_widget_id&auditoriumId=$auditoriumId&talkId=$talkId#displayName=$matrix_display_name&avatarUrl=$matrix_avatar_url&userId=$matrix_user_id&roomId=$matrix_room_id&auth=openidtoken-jwt",
+                url: config.webserver.publicBaseUrl + "/widgets/talk.html?widgetId=$matrix_widget_id&auditoriumId=$auditoriumId&talkId=$talkId&theme=$theme#displayName=$matrix_display_name&avatarUrl=$matrix_avatar_url&userId=$matrix_user_id&roomId=$matrix_room_id&auth=openidtoken-jwt",
                 data: {
                     title: await talk.getName(),
                     auditoriumId: await talk.getAuditoriumId(),
@@ -95,7 +95,7 @@ export class LiveWidget {
                 waitForIframeLoad: true,
                 name: "Livestream / Q&A",
                 avatar_url: config.livestream.widgetAvatar,
-                url: config.webserver.publicBaseUrl + "/widgets/hybrid.html?widgetId=$matrix_widget_id&roomId=$matrix_room_id#displayName=$matrix_display_name&avatarUrl=$matrix_avatar_url&userId=$matrix_user_id&roomId=$matrix_room_id&auth=openidtoken-jwt",
+                url: config.webserver.publicBaseUrl + "/widgets/hybrid.html?widgetId=$matrix_widget_id&roomId=$matrix_room_id&theme=$theme#displayName=$matrix_display_name&avatarUrl=$matrix_avatar_url&userId=$matrix_user_id&roomId=$matrix_room_id&auth=openidtoken-jwt",
                 data: {
                     title: "Join the conference to ask questions",
                 },
@@ -117,7 +117,7 @@ export class LiveWidget {
                 waitForIframeLoad: true,
                 name: "Upvoted messages",
                 avatar_url: config.livestream.widgetAvatar,
-                url: config.webserver.publicBaseUrl + "/widgets/scoreboard.html?widgetId=$matrix_widget_id&auditoriumId=$auditoriumId&talkId=$talkId",
+                url: config.webserver.publicBaseUrl + "/widgets/scoreboard.html?widgetId=$matrix_widget_id&auditoriumId=$auditoriumId&talkId=$talkId&theme=$theme",
                 data: {
                     title: title,
                     auditoriumId: await talk.getAuditoriumId(),

--- a/src/web.ts
+++ b/src/web.ts
@@ -40,6 +40,7 @@ export function renderAuditoriumWidget(req: Request, res: Response) {
     });
 
     return res.render('auditorium.liquid', {
+        theme: req.query?.['theme'] === 'dark' ? 'dark' : 'light',
         videoUrl: streamUrl,
         roomName: audId,
     });
@@ -81,6 +82,7 @@ export async function renderTalkWidget(req: Request, res: Response) {
     });
 
     return res.render('talk.liquid', {
+        theme: req.query?.['theme'] === 'dark' ? 'dark' : 'light',
         videoUrl: streamUrl,
         roomName: await talk.getName(),
         conferenceDomain: config.livestream.jitsiDomain,
@@ -101,6 +103,7 @@ export async function renderHybridWidget(req: Request, res: Response) {
     });
 
     return res.render('talk.liquid', { // it's the same widget
+        theme: req.query?.['theme'] === 'dark' ? 'dark' : 'light',
         videoUrl: streamUrl,
         roomName: "Livestream / Q&A",
         conferenceDomain: config.livestream.jitsiDomain,
@@ -185,6 +188,7 @@ export async function renderScoreboardWidget(req: Request, res: Response) {
     }
 
     return res.render('scoreboard.liquid', {
+        theme: req.query?.['theme'] === 'dark' ? 'dark' : 'light',
         trackingAlias: await aud.getCanonicalAlias(),
         trackingId: aud.roomId,
     });

--- a/web/auditorium.liquid
+++ b/web/auditorium.liquid
@@ -5,7 +5,7 @@
     <title>{{roomName}}</title>
     <meta name="org.matrix.confbot.video_url" content="{{videoUrl}}" />
 </head>
-<body>
+<body class="{{theme}}">
     <noscript>Sorry, you'll need JavaScript to use this widget.</noscript>
     <div id="messages">
         <h3>Waiting for stream</h3>

--- a/web/common.scss
+++ b/web/common.scss
@@ -21,7 +21,20 @@ html, body {
   margin: 0;
   height: 100%; /* to trick the layout into working */
   font-family: 'Inter', sans-serif;
-  background-color: #fff;
+}
+
+body.light {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+body.dark {
+  background-color: #15191e;
+  color: #ffffff;
+}
+
+a:hover, a:link, a:visited {
+  color: #238CF5;
 }
 
 #livestream {

--- a/web/scoreboard.liquid
+++ b/web/scoreboard.liquid
@@ -6,7 +6,7 @@
     <meta name="org.matrix.confbot.room_alias" content="{{trackingAlias}}" />
     <meta name="org.matrix.confbot.room_id" content="{{trackingId}}" />
 </head>
-<body id="scoreboard">
+<body id="scoreboard" class="{{theme}}">
     <noscript>Sorry, you'll need JavaScript to use this widget.</noscript>
     <div id="scoreboardQABanner" class="banner"></div>
     <h3>Scoreboard for <a href="https://matrix.to/#/{{trackingAlias}}" onclick="intercept(event)">{{trackingAlias}}</a></h3>

--- a/web/talk.liquid
+++ b/web/talk.liquid
@@ -10,7 +10,7 @@
     <meta name="org.matrix.confbot.livestream_start_time" content="{{livestreamStartTime}}" />
     <meta name="org.matrix.confbot.livestream_end_time" content="{{livestreamEndTime}}" />
 </head>
-<body>
+<body class="{{theme}}">
     <noscript>Sorry, you'll need JavaScript to use this widget.</noscript>
     <div id="messages">
         <h3>Waiting for stream</h3>


### PR DESCRIPTION
When widgets are loaded, their theme is determined based on a new query
parameter. If a user changes their theme afterwards, the widget will
remain on the old theme. In the future it may be possible to respond to
such theme changes, but it is not currently supported on Element Web.

Closes #46.

![image](https://user-images.githubusercontent.com/8349537/150547490-ea70a00b-3f19-4ba4-88c8-aa61b7a2fb29.png)

![image](https://user-images.githubusercontent.com/8349537/150547589-a4e0f5d0-e85f-4cc7-a0f0-fef2a70d2a01.png)
