### PR TITLE
Make Q&A messaging for attendees clearer

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -309,7 +309,7 @@ export class Scheduler {
                     `<h3>${await confTalk.getName()}</h3>` +
                     `<p><b>There is no video for this talk.</b> ` +
                     `Ask your questions here and they'll try to answer them! ` +
-                    `The questions with the most 👍 votes will be answered first.</p>`,
+                    `The questions with the most 👍 votes are most visible to the speaker.</p>`,
                 );
                 return;
             }

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -304,11 +304,20 @@ export class Scheduler {
             await this.scoreboard.resetScoreboard(confAud.roomId);
             if (!task.talk.prerecorded) {
                 await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk is not pre-recorded.</h3><p>You are entering the Q&A for your talk's duration now.</p>`);
-                await this.client.sendHtmlText(confAud.roomId, `<h3>${await confTalk.getName()}</h3><p><b>There is no video for this talk.</b> Ask your questions here and they'll try to answer them!</p>`);
+                await this.client.sendHtmlText(
+                    confAud.roomId,
+                    `<h3>${await confTalk.getName()}</h3>` +
+                    `<p><b>There is no video for this talk.</b> ` +
+                    `Ask your questions here and they'll try to answer them!</p>`,
+                );
                 return;
             }
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk is starting shortly.</h3>`);
-            await this.client.sendHtmlText(confAud.roomId, `<h3>Up next: ${await confTalk.getName()}</h3><p>Ask your questions here for the Q&A at the end of the talk.</p>`);
+            await this.client.sendHtmlText(
+                confAud.roomId,
+                `<h3>Up next: ${await confTalk.getName()}</h3>` +
+                `<p>Ask your questions here for the Q&A at the end of the talk.</p>`,
+            );
         } else if (task.type === ScheduledTaskType.TalkQA) {
             if (!task.talk.prerecorded) return;
             await this.client.sendHtmlText(
@@ -317,7 +326,11 @@ export class Scheduler {
                 `<p>Remember that the broadcast feed is buffered and lags many seconds behind. ` +
                 `Do not wait for it to finish, otherwise you will create a long pause!</p>`,
             );
-            await this.client.sendHtmlText(confAud.roomId, `<h3>Q&A is starting shortly</h3><p>Feel free to continue asking questions in this room for the speakers - the conversation will continue in the hallway after the Q&A.</p>`);
+            await this.client.sendHtmlText(
+                confAud.roomId,
+                `<h3>Q&A is starting shortly</h3>` +
+                `<p>Feel free to continue asking questions in this room for the speakers - the conversation will continue in the hallway after the Q&A.</p>`,
+            );
         } else if (task.type === ScheduledTaskType.TalkEnd) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk has ended - opening up this room to all attendees.</h3><p>@room - They won't see the history in this room.</p>`);
             const widget = await LiveWidget.forTalk(confTalk, this.client);

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -331,7 +331,7 @@ export class Scheduler {
             await this.client.sendHtmlText(
                 confAud.roomId,
                 `<h3>Q&A is starting shortly</h3>` +
-                `<p>Ask questions in this room for the speakers - the questions with the most 👍 votes will be answered first.</p>`,
+                `<p>Ask questions in this room for the speakers - the questions with the most 👍 votes are most visible to the speaker.</p>`,
             );
         } else if (task.type === ScheduledTaskType.TalkEnd) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk has ended - opening up this room to all attendees.</h3><p>@room - They won't see the history in this room.</p>`);

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -318,7 +318,7 @@ export class Scheduler {
                 confAud.roomId,
                 `<h3>Up next: ${await confTalk.getName()}</h3>` +
                 `<p>During the talk, you can ask questions here for the Q&A at the end. ` +
-                `The questions with the most 👍 votes will be answered first.</p>`,
+                `The questions with the most 👍 votes are most visible to the speaker.</p>`,
             );
         } else if (task.type === ScheduledTaskType.TalkQA) {
             if (!task.talk.prerecorded) return;

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -308,7 +308,8 @@ export class Scheduler {
                     confAud.roomId,
                     `<h3>${await confTalk.getName()}</h3>` +
                     `<p><b>There is no video for this talk.</b> ` +
-                    `Ask your questions here and they'll try to answer them!</p>`,
+                    `Ask your questions here and they'll try to answer them! ` +
+                    `The questions with the most 👍 votes will be answered first.</p>`,
                 );
                 return;
             }
@@ -316,7 +317,8 @@ export class Scheduler {
             await this.client.sendHtmlText(
                 confAud.roomId,
                 `<h3>Up next: ${await confTalk.getName()}</h3>` +
-                `<p>Ask your questions here for the Q&A at the end of the talk.</p>`,
+                `<p>During the talk, you can ask questions here for the Q&A at the end. ` +
+                `The questions with the most 👍 votes will be answered first.</p>`,
             );
         } else if (task.type === ScheduledTaskType.TalkQA) {
             if (!task.talk.prerecorded) return;
@@ -329,7 +331,7 @@ export class Scheduler {
             await this.client.sendHtmlText(
                 confAud.roomId,
                 `<h3>Q&A is starting shortly</h3>` +
-                `<p>Feel free to continue asking questions in this room for the speakers - the conversation will continue in the hallway after the Q&A.</p>`,
+                `<p>Ask questions in this room for the speakers - the questions with the most 👍 votes will be answered first.</p>`,
             );
         } else if (task.type === ScheduledTaskType.TalkEnd) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk has ended - opening up this room to all attendees.</h3><p>@room - They won't see the history in this room.</p>`);


### PR DESCRIPTION
After testing, one of the testers gave the following feedback:
> It isn't immediately clear what becomes a question; it seems that for a message to become a question, it has to be upvoted which wasn't clear to me in the beginning

Let's encourage attendees to thumbs up questions more clearly.