### PR TITLE
Split out the one-minute-before-end-of-talk warning for the talk room

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -216,6 +216,10 @@ conference:
     # such as sponsor segments. If this is built into the table already then set this to zero.
     schedulePreBufferSeconds: 30
 
+    # The duration in seconds added to the talk `duration` to account for postroll material
+    # such as sponsor segments. If this is built into the table already then set this to zero.
+    schedulePostBufferSeconds: 30
+
   # Various prefixes used by the bot when parsing information.
   prefixes:
     # The prefixes for the rooms listed in the pentabarf definition which

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -212,9 +212,9 @@ conference:
     # how you (the bot's admin) are the one entering it: don't do that to yourself.
     tblSchedule: "view_matrix_bot_export_schedule"
 
-    # The time in seconds added to the presentation_length to account for preroll material such
-    # as sponsor segments. If this is built into the table already then set this to zero.
-    scheduleBufferSeconds: 30
+    # The duration in seconds added to the `presentation_length` to account for preroll material
+    # such as sponsor segments. If this is built into the table already then set this to zero.
+    schedulePreBufferSeconds: 30
 
   # Various prefixes used by the bot when parsing information.
   prefixes:

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,7 @@ interface IConfig {
             tblPeople: string;
             tblSchedule: string;
             schedulePreBufferSeconds: number;
+            schedulePostBufferSeconds: number;
         };
     };
     ircBridge: IRCBridgeOpts;

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,7 @@ interface IConfig {
             sslmode: string;
             tblPeople: string;
             tblSchedule: string;
-            scheduleBufferSeconds: number;
+            schedulePreBufferSeconds: number;
         };
     };
     ircBridge: IRCBridgeOpts;

--- a/src/db/DbTalk.ts
+++ b/src/db/DbTalk.ts
@@ -33,4 +33,11 @@ export interface IDbTalk extends IRawDbTalk {
      * non-prerecorded talks.
      */
     livestream_start_datetime: number; // ms timestamp, utc
+
+    /**
+     * The end time of the talk's livestream, as a Unix timestamp in milliseconds.
+     *
+     * This may occur before the end of the talk.
+     */
+    livestream_end_datetime: number; // ms timestamp, utc
 }

--- a/src/db/PentaDb.ts
+++ b/src/db/PentaDb.ts
@@ -139,12 +139,14 @@ export class PentaDb {
             // For live talks, both the preroll and interroll are shown, followed by the live talk.
             livestreamStartDatetime = talk.start_datetime + config.conference.database.schedulePreBufferSeconds * 1000;
         }
+        const livestreamEndDatetime = talk.end_datetime - config.conference.database.schedulePostBufferSeconds * 1000;
 
         return {
             ...talk,
 
             qa_start_datetime: qaStartDatetime,
             livestream_start_datetime: livestreamStartDatetime,
+            livestream_end_datetime: livestreamEndDatetime,
         };
     }
 

--- a/src/db/PentaDb.ts
+++ b/src/db/PentaDb.ts
@@ -129,7 +129,7 @@ export class PentaDb {
     }
 
     private postprocessDbTalk(talk: IRawDbTalk): IDbTalk {
-        const qaStartDatetime = talk.qa_start_datetime + config.conference.database.scheduleBufferSeconds * 1000;
+        const qaStartDatetime = talk.qa_start_datetime + config.conference.database.schedulePreBufferSeconds * 1000;
         let livestreamStartDatetime: number;
         if (talk.prerecorded) {
             // For prerecorded talks, a preroll is shown, followed by the talk recording, then an
@@ -137,7 +137,7 @@ export class PentaDb {
             livestreamStartDatetime = qaStartDatetime;
         } else {
             // For live talks, both the preroll and interroll are shown, followed by the live talk.
-            livestreamStartDatetime = talk.start_datetime + config.conference.database.scheduleBufferSeconds * 1000;
+            livestreamStartDatetime = talk.start_datetime + config.conference.database.schedulePreBufferSeconds * 1000;
         }
 
         return {

--- a/src/web.ts
+++ b/src/web.ts
@@ -114,7 +114,7 @@ export async function renderTalkWidget(req: Request, res: Response) {
         conferenceDomain: config.livestream.jitsiDomain,
         conferenceId: base32.stringify(Buffer.from(talk.roomId), { pad: false }).toLowerCase(),
         livestreamStartTime: dbTalk?.livestream_start_datetime ?? "",
-        livestreamEndTime: dbTalk?.end_datetime ?? "",
+        livestreamEndTime: dbTalk?.livestream_end_datetime ?? "",
     });
 }
 


### PR DESCRIPTION
It's more useful for speakers in the talk room to know when the
livestream is ending, rather than when their talk slot is ending.

Part of the work for #100.

Built on top of PR #102.