### PR TITLE
Set IRC bridge PL when plumbing

### DIFF
--- a/src/IRCBridge.ts
+++ b/src/IRCBridge.ts
@@ -51,6 +51,10 @@ export class IRCBridge {
         }
     }
 
+    public get botUserId() {
+        return this.config.botUserId;
+    }
+
     public async deriveChannelName(auditorium: Auditorium) {
         const name = await auditorium.getName();
         if (!name) {

--- a/src/commands/IrcPlumbCommand.ts
+++ b/src/commands/IrcPlumbCommand.ts
@@ -19,6 +19,7 @@ import { LogLevel, LogService, MatrixClient } from "matrix-bot-sdk";
 import { Conference } from "../Conference";
 import { IRCBridge } from "../IRCBridge";
 import { logMessage } from "../LogProxy";
+import { KickPowerLevel } from "../models/room_kinds";
 
 const PLUMB_WAIT_MS = 1000;
 
@@ -81,6 +82,13 @@ export class IrcPlumbCommand implements ICommand {
         }
         try {
             await this.ircBridge.plumbChannelToRoom(channel, resolvedRoomId);
+        } catch (ex) {
+            LogService.warn("IrcPlumbCommand", ex);
+            return await logMessage(LogLevel.WARN, "IrcPlumbCommand", `Could not plumb channel to room`);
+        }
+        // The bridge needs the ability to kick KLINED users.
+        try {
+            await client.setUserPowerLevel(this.ircBridge.botUserId, resolvedRoomId, KickPowerLevel);
         } catch (ex) {
             LogService.warn("IrcPlumbCommand", ex);
             return await logMessage(LogLevel.WARN, "IrcPlumbCommand", `Could not plumb channel to room`);

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -24,11 +24,13 @@ import {
 } from "./room_state";
 import config from "../config";
 
+export const KickPowerLevel = 50;
+
 export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = {
     ban: 50,
     events_default: 0,
     invite: 50,
-    kick: 50,
+    kick: KickPowerLevel,
     redact: 50,
     state_default: 50,
     users_default: 0,


### PR DESCRIPTION
In order to kick users banned from the IRC network, otherwise the channels will fail to bridge I->M