### PR TITLE
Allow disabling IRC bridge by not configuring one, to prevent crash [rei:wedf/a]

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -261,20 +261,21 @@ conference:
     #  # The prefixes of rooms which belong in the subspace
     #  prefixes: ["S."]
 
-# Options related to the IRC bridge.
-ircBridge:
+# Options related to the IRC bridge. Set to null if you don't use an IRC bridge.
+ircBridge: null
+#ircBridge:
   # The nick to use when taking ownership of channels
-  botNick: 'confbot'
-  botPassword: 'a_secret_password'
+  #botNick: 'confbot'
+  #botPassword: 'a_secret_password'
 
   # The server name of the IRCd
-  serverName: 'localhost'
+  #serverName: 'localhost'
 
   # The port of the IRCd
-  port: 6667
+  #port: 6667
 
   # The userId of the irc bridge
-  botUserId: '@appservice-irc:example.com'
+  #botUserId: '@appservice-irc:example.com'
 
   # The allowed channel prefix of the bot
-  channelPrefix: '#conference-'
+  #channelPrefix: '#conference-'

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,7 @@ interface IConfig {
             schedulePostBufferSeconds: number;
         };
     };
-    ircBridge: IRCBridgeOpts | undefined;
+    ircBridge: IRCBridgeOpts | null;
 
     RUNTIME: {
         client: MatrixClient;

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,7 @@ interface IConfig {
             schedulePostBufferSeconds: number;
         };
     };
-    ircBridge: IRCBridgeOpts;
+    ircBridge: IRCBridgeOpts | undefined;
 
     RUNTIME: {
         client: MatrixClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,10 @@ const scoreboard = new Scoreboard(conference, client);
 const scheduler = new Scheduler(client, conference, scoreboard);
 config.RUNTIME.scheduler = scheduler;
 
-const ircBridge = new IRCBridge(config.ircBridge, client);
+let ircBridge: IRCBridge | null = null;
+if (config.ircBridge != null) {
+    ircBridge = new IRCBridge(config.ircBridge, client);
+}
 config.RUNTIME.ircBridge = ircBridge;
 
 const checkins = new CheckInMap(client, conference);
@@ -140,7 +143,11 @@ let userId;
     await client.start();
 
     // Needs to happen after the sync loop has started
-    await ircBridge.setup();
+    if (ircBridge !== null) {
+        // Note that the IRC bridge will cause a crash if wrongly configured, so be cautious that it's not
+        // wrongly enabled in conferences without one.
+        await ircBridge.setup();
+    }
 })();
 
 function registerCommands() {


### PR DESCRIPTION











<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:wedf/a
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#130|👉 Allow disabling IRC bridge by not configuring one, to prevent crash|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/130?label=Pending)|-|
|#131|Fix !schedule view falling over with long schedules|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/131?label=Pending)|#130|
|#133|*(Draft) Try to disconnect the Conference bot from being so reliant on Pentabarf (best effort)*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/133?label=Pending)|#131|
|#132|*(Draft) Add a JSON schedule loader*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/132?label=Pending)|#133|
|#134|*(Draft) Fix some misc bugs*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/134?label=Pending)|#132|
|#135|*(Draft) Disable features relating to Q&A if desired*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/135?label=Pending)|#134|
|#136|*(Draft) Refactor the backends to be called backends*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/136?label=Pending)|#135|
|#137|*(Draft) Use a custom 'locator' state event rather than `m.room.create`.*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/137?label=Pending)|#136|
|#138|*(Draft) Add a schedule cache as a fallback for if the original schedule goes offline*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/138?label=Pending)|#137|
|#139|*(Draft) Add a status command to get some information about the bot and its situation*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/139?label=Pending)|#138|
<!---GHSTACKCLOSE-->










