### PR TITLE
Disable features relating to Q&A if desired [rei:wedf/a]

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -320,8 +320,8 @@ export class Scheduler {
                     confAud.roomId,
                     `<h3>${await confTalk.getName()}</h3>` +
                     `<p><b>There is no video for this talk.</b> ` +
-                    `Ask your questions here and they'll try to answer them! ` +
-                    `The questions with the most 👍 votes are most visible to the speaker.</p>`,
+                    (task.talk.qa_startTime !== null ? `Ask your questions here and they'll try to answer them! ` +
+                    `The questions with the most 👍 votes are most visible to the speaker.</p>` : ''),
                 );
                 return;
             }
@@ -329,8 +329,8 @@ export class Scheduler {
             await this.client.sendHtmlText(
                 confAud.roomId,
                 `<h3>Up next: ${await confTalk.getName()}</h3>` +
-                `<p>During the talk, you can ask questions here for the Q&A at the end. ` +
-                `The questions with the most 👍 votes are most visible to the speaker.</p>`,
+                (task.talk.qa_startTime !== null ? `<p>During the talk, you can ask questions here for the Q&A at the end. ` +
+                `The questions with the most 👍 votes are most visible to the speaker.</p>` : ''),
             );
         } else if (task.type === ScheduledTaskType.TalkQA) {
             if (!task.talk.prerecorded) return;
@@ -370,7 +370,7 @@ export class Scheduler {
             if (!task.talk.prerecorded) {
                 await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk starts in about 5 minutes</h3><p><b>Your talk is not pre-recorded.</b> Your talk's full duration will be Q&A.</p>`);
             } else {
-                await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk starts in about 5 minutes</h3><p>Please join the Jitsi conference at the top of this room to prepare for your Q&A.</p>`);
+                await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk starts in about 5 minutes</h3>` + (task.talk.qa_startTime !== null ? `<p>Please join the Jitsi conference at the top of this room to prepare for your Q&A.</p>` : ''));
             }
         } else if (task.type === ScheduledTaskType.TalkQA5M) {
             if (getStartTime(task) < task.talk.startTime) {
@@ -392,7 +392,7 @@ export class Scheduler {
             await this.scoreboard.showQACountdown(confAud.roomId, task.talk.qa_startTime);
         } else if (task.type === ScheduledTaskType.TalkEnd5M) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk ends in about 5 minutes</h3><p>The next talk will start automatically after yours. In 5 minutes, this room will be opened up for anyone to join. They will not be able to see history.</p>`);
-            await this.client.sendHtmlText(confAud.roomId, `<h3>This talk ends in about 5 minutes</h3><p>Ask questions here for the speakers!</p>`);
+            await this.client.sendHtmlText(confAud.roomId, `<h3>This talk ends in about 5 minutes</h3>` + (task.talk.qa_startTime !== null ? `<p>Ask questions here for the speakers!</p>`: ''));
         } else if (task.type === ScheduledTaskType.TalkLivestreamEnd1M) {
             await this.client.sendHtmlText(confTalk.roomId, `<h3>Your talk ends in about 1 minute!</h3><p>The next talk will start automatically after yours. Wrap it up!</p>`);
         } else if (task.type === ScheduledTaskType.TalkEnd1M) {


### PR DESCRIPTION
We remove mentions of the Q&A system in audience announcements to prevent confusion, if Q&A is disabled.
May remove things from the staff side as well, but not sure yet...



<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:wedf/a
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#130|Allow disabling IRC bridge by not configuring one, to prevent crash|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/130?label=Pending)|-|
|#131|Fix !schedule view falling over with long schedules|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/131?label=Pending)|#130|
|#133|*(Draft) Try to disconnect the Conference bot from being so reliant on Pentabarf (best effort)*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/133?label=Pending)|#131|
|#132|*(Draft) Add a JSON schedule loader*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/132?label=Pending)|#133|
|#134|*(Draft) Fix some misc bugs*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/134?label=Pending)|#132|
|#135|👉 *(Draft) Disable features relating to Q&A if desired*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/135?label=Pending)|#134|
|#136|*(Draft) Refactor the backends to be called backends*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/136?label=Pending)|#135|
|#137|*(Draft) Use a custom 'locator' state event rather than `m.room.create`.*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/137?label=Pending)|#136|
|#138|*(Draft) Add a schedule cache as a fallback for if the original schedule goes offline*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/138?label=Pending)|#137|
|#139|*(Draft) Add a status command to get some information about the bot and its situation*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/139?label=Pending)|#138|
<!---GHSTACKCLOSE-->



