### PR TITLE
Use a custom 'locator' state event rather than `m.room.create`. [rei:wedf/a]

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -137,11 +137,11 @@ conference:
   timezone: "Europe/Brussels"
 
   # The various support rooms the bot supports. They will be created if they
-  # haven't already.
+  # haven't already. If commented out, they won't be created.
   supportRooms:
-    speakers: "#speakers:example.org"
-    specialInterest: "#stands:example.org"
-    coordinators: "#coordinators:example.org"
+    #speakers: "#speakers:example.org"
+    #specialInterest: "#stands:example.org"
+    #coordinators: "#coordinators:example.org"
 
   # How far in the future the bot should be looking before considering something "finalized".
   # Should never be less than 5 minutes.

--- a/docs/using-existing-space.md
+++ b/docs/using-existing-space.md
@@ -1,0 +1,32 @@
+# Using the conference bot with an existing space
+
+The conference bot is normally responsible for creating the top-level space of
+the conference and inviting *you* to it.
+This is undesirable if you already have a space for your conference and you don't
+want to have to move everything (and everyone) over to a new space.
+
+With a little bit of manual setup, it's possible to make the bot re-use an existing space.
+Here's how:
+
+ 1. Invite the bot to the space.
+ 2. Join the bot to the space by sending `!conference join #space-id:example.org` in its management room.
+ 3. Promote the bot to at least moderator privileges (power level 50): enough
+    to send state events and add new rooms and spaces to the top-level space.
+    **TODO:** Power level 100 might be needed so that the bot can add new admins...
+ 4. Send a 'locator' **state event** into the space.
+    This is currently a little bit fiddly, but here are the steps to do it in Element Web/Desktop:
+     1. Enable developer mode by going to a text room, typing `/devtools` and enabling
+        the toggle switch that says 'developer mode'.
+     2. Now right click on the space in the sidebar on the left-hand-side.
+        Since enabling developer mode, you should now see an option 'See room timeline (devtools)'. Select this.
+     3. You will now see the timeline (roughly: chat view) for the space,
+        as though the space was just a normal text room.
+     4. Type `/devtools`, go to 'Explore room state' and 'Send a new state event'.
+     5. Set the state event type to `org.matrix.confbot.locator`, leave the state key blank and set the content to
+        ```json
+        {"kind": "conference_space", "conferenceId": "your-conf-id"}
+        ```
+        (replace `your-conf-id` with the id of your conference as specified in the configuration file!)
+
+
+This procedure could be improved in the future.

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -223,7 +223,10 @@ export class Conference {
                                 }
                                 break;
                             case RoomKind.SpecialInterest:
-                                this.interestRooms[locatorEvent[RSC_SPECIAL_INTEREST_ID]] = new InterestRoom(roomId, this.client, this, locatorEvent[RSC_SPECIAL_INTEREST_ID]);
+                                const interestId = locatorEvent[RSC_SPECIAL_INTEREST_ID];
+                                if (this.backend.interestRooms.has(interestId)) {
+                                    this.interestRooms[interestId] = new InterestRoom(roomId, this.client, this, interestId);
+                                }
                                 break;
                             default:
                                 break;

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -189,7 +189,7 @@ export class Conference {
 
                     if (locatorEvent[RSC_CONFERENCE_ID] === this.id) {
                         switch (locatorEvent[RSC_ROOM_KIND_FLAG]) {
-                            case RoomKind.Conference:
+                            case RoomKind.ConferenceDb:
                                 this.dbRoom = new MatrixRoom(roomId, this.client, this);
                                 break;
                             case RoomKind.Auditorium:

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -189,13 +189,22 @@ export class Conference {
                                 this.dbRoom = new MatrixRoom(roomId, this.client, this);
                                 break;
                             case RoomKind.Auditorium:
-                                this.auditoriums[locatorEvent[RSC_AUDITORIUM_ID]] = new Auditorium(roomId, this.client, this);
+                                const auditoriumId = locatorEvent[RSC_AUDITORIUM_ID];
+                                if (this.backend.auditoriums.has(auditoriumId)) {
+                                    this.auditoriums[auditoriumId] = new Auditorium(roomId, this.backend.auditoriums.get(auditoriumId), this.client, this);
+                                }
                                 break;
                             case RoomKind.AuditoriumBackstage:
-                                this.auditoriumBackstages[locatorEvent[RSC_AUDITORIUM_ID]] = new AuditoriumBackstage(roomId, this.client, this);
+                                const auditoriumBsId = locatorEvent[RSC_AUDITORIUM_ID];
+                                if (this.backend.auditoriums.has(auditoriumBsId)) {
+                                    this.auditoriumBackstages[auditoriumBsId] = new AuditoriumBackstage(roomId, this.backend.auditoriums.get(auditoriumBsId), this.client, this);
+                                }
                                 break;
                             case RoomKind.Talk:
-                                this.talks[locatorEvent[RSC_TALK_ID]] = new Talk(roomId, this.client, this);
+                                const talkId = locatorEvent[RSC_TALK_ID];
+                                if (this.backend.talks.has(talkId)) {
+                                    this.talks[talkId] = new Talk(roomId, this.backend.talks.get(talkId), this.client, this);
+                                }
                                 break;
                             case RoomKind.SpecialInterest:
                                 this.interestRooms[locatorEvent[RSC_SPECIAL_INTEREST_ID]] = new InterestRoom(roomId, this.client, this, locatorEvent[RSC_SPECIAL_INTEREST_ID]);
@@ -462,7 +471,7 @@ export class Conference {
         }));
         await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + auditorium.slug, auditorium.id);
         await this.dbRoom.addDirectChild(roomId);
-        this.auditoriums[auditorium.id] = new Auditorium(roomId, this.client, this);
+        this.auditoriums[auditorium.id] = new Auditorium(roomId, auditorium, this.client, this);
 
         // TODO: Send widgets after room creation
         // const widget = await LiveWidget.forAuditorium(this.auditoriums[auditorium.id], this.client);
@@ -494,7 +503,7 @@ export class Conference {
         }));
         await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + auditorium.slug + "-backstage", auditorium.id);
         await this.dbRoom.addDirectChild(roomId);
-        this.auditoriumBackstages[auditorium.id] = new AuditoriumBackstage(roomId, this.client, this);
+        this.auditoriumBackstages[auditorium.id] = new AuditoriumBackstage(roomId, auditorium, this.client, this);
 
         return this.auditoriumBackstages[auditorium.id];
     }
@@ -523,7 +532,7 @@ export class Conference {
             }));
             await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + (await auditorium.getSlug()) + '-' + talk.slug);
             await assignAliasVariations(this.client, roomId, config.conference.prefixes.aliases + 'talk-' + talk.id);
-            this.talks[talk.id] = new Talk(roomId, this.client, this);
+            this.talks[talk.id] = new Talk(roomId, talk, this.client, this);
         } else {
             roomId = this.talks[talk.id].roomId;
 

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -34,7 +34,7 @@ import {
     makeParentRoom,
     makeStoredAuditorium,
     makeStoredConference, makeStoredInterestRoom,
-    makeStoredPerson,
+    makeStoredPersonOverride,
     makeStoredSpace,
     makeStoredTalk,
     RS_3PID_PERSON_ID,
@@ -75,6 +75,10 @@ export class Conference {
     private interestRooms: {
         [interestId: string]: InterestRoom;
     } = {};
+
+    /**
+     * Overrides of people. Used to e.g. associate someone's Matrix ID after registration through the e-mail invitation.
+     */
     private people: {
         [personId: string]: IPerson;
     } = {};
@@ -240,6 +244,7 @@ export class Conference {
         if (!this.dbRoom) return;
         const dbState = (await this.client.getRoomState(this.dbRoom.roomId)).filter(s => !!s.content);
 
+        // Load person overrides
         const people = dbState.filter(s => s.type === RS_STORED_PERSON).map(s => s.content as IPerson);
         for (const person of people) {
             this.people[person.id] = person;
@@ -553,7 +558,7 @@ export class Conference {
     }
 
     public async createUpdatePerson(person: IPerson): Promise<IPerson> {
-        const storedPerson = makeStoredPerson(person);
+        const storedPerson = makeStoredPersonOverride(person);
         await this.client.sendStateEvent(this.dbRoom.roomId, storedPerson.type, storedPerson.state_key, storedPerson.content);
         this.people[storedPerson.content.id] = storedPerson.content;
         return this.people[storedPerson.content.id];

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -187,7 +187,13 @@ export class Conference {
             // Process batches of rooms in parallel, since there may be a few hundred
             const tasks = roomIds.slice(i, i + batchSize).map(
                 async roomId => {
-                    let locatorEvent = await this.client.getRoomStateEvent(roomId, RS_LOCATOR, "");
+                    let locatorEvent;
+                    try {
+                        locatorEvent = await this.client.getRoomStateEvent(roomId, RS_LOCATOR, "");
+                    } catch (err) {
+                        LogService.info("Conference", `Can't read locator in room: ${JSON.stringify(err)}`)
+                        return;
+                    }
 
                     if (locatorEvent[RSC_CONFERENCE_ID] === this.id) {
                         switch (locatorEvent[RSC_ROOM_KIND_FLAG]) {

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -31,6 +31,7 @@ import {
 import { IAuditorium, IConference, IInterestRoom, IPerson, ITalk, Role } from "./models/schedule";
 import {
     IStoredSubspace,
+    makeAssociatedSpace,
     makeAuditoriumBackstageLocator,
     makeAuditoriumLocator,
     makeDbLocator,
@@ -38,7 +39,6 @@ import {
     makeParentRoom,
     makeRootSpaceLocator,
     makeStoredPersonOverride,
-    makeStoredSpace,
     makeTalkLocator,
     RS_3PID_PERSON_ID,
     RS_STORED_PERSON,
@@ -312,7 +312,6 @@ export class Conference {
                 name: `[DB] Conference ${conference.title}`,
                 initial_state: [
                     makeDbLocator(this.id),
-                    makeStoredSpace(space.roomId),
                 ],
             }));
 
@@ -492,7 +491,7 @@ export class Conference {
             initial_state: [
                 makeAuditoriumLocator(this.id, auditorium.id),
                 makeParentRoom(this.dbRoom.roomId),
-                makeStoredSpace(audSpace.roomId),
+                makeAssociatedSpace(audSpace.roomId),
             ],
             name: auditorium.name,
         }));
@@ -567,7 +566,7 @@ export class Conference {
         // Ensure that the room appears within the correct space.
         await auditorium.addDirectChild(roomId);
         const startTime = new Date(talk.startTime).toISOString();
-        await (await auditorium.getSpace()).addChildRoom(roomId, { order: `3-talk-${startTime}` });
+        await (await auditorium.getAssociatedSpace()).addChildRoom(roomId, { order: `3-talk-${startTime}` });
 
         return this.talks[talk.id];
     }

--- a/src/backends/json/JsonScheduleLoader.ts
+++ b/src/backends/json/JsonScheduleLoader.ts
@@ -105,6 +105,7 @@ export class JsonScheduleLoader {
             name: stream.stream_name,
             kind: RoomKind.Auditorium,
             talks
+            conferenceId
         };
     }
 

--- a/src/backends/json/JsonScheduleLoader.ts
+++ b/src/backends/json/JsonScheduleLoader.ts
@@ -20,12 +20,11 @@ export class JsonScheduleLoader {
         // TODO: Validate and give errors. Assuming it's correct is a bit cheeky.
         const jsonSchedule = jsonDesc as JSONSchedule;
 
-        this.conferenceId = ""; // TODO What's this?
         this.auditoriums = new Map();
         this.talks = new Map();
 
         for (let aud of jsonSchedule.streams) {
-            const auditorium = this.convertAuditorium(aud, this.conferenceId);
+            const auditorium = this.convertAuditorium(aud);
             if (this.auditoriums.has(auditorium.id)) {
                 throw `Conflict in auditorium ID «${auditorium.id}»!`;
             }
@@ -60,7 +59,7 @@ export class JsonScheduleLoader {
         };
     }
 
-    private convertTalk(talk: JSONTalk, conferenceId: string, auditoriumId: string): ITalk {
+    private convertTalk(talk: JSONTalk, auditoriumId: string): ITalk {
         const startMoment = moment.utc(talk.start, moment.ISO_8601, true);
         const endMoment = moment.utc(talk.end, moment.ISO_8601, true);
 
@@ -70,7 +69,6 @@ export class JsonScheduleLoader {
             subtitle: talk.description, // TODO is this valid?
             slug: this.slugify(talk.title),
 
-            conferenceId,
             auditoriumId,
             prerecorded: true, // TODO
             qa_startTime: null, // TODO
@@ -85,13 +83,13 @@ export class JsonScheduleLoader {
         };
     }
 
-    private convertAuditorium(stream: JSONStream, conferenceId: string): IAuditorium {
+    private convertAuditorium(stream: JSONStream): IAuditorium {
         const auditoriumId = this.slugify(stream.stream_name);
 
         const talks: Map<TalkId, ITalk> = new Map();
 
         for (let unconvTalk of stream.talks) {
-            const talk = this.convertTalk(unconvTalk, conferenceId, auditoriumId);
+            const talk = this.convertTalk(unconvTalk, auditoriumId);
             if (talks.has(talk.id)) {
                 const conflictingTalk = talks.get(talk.id);
                 throw `Talk ID ${talk.id} is not unique — occupied by both «${talk.title}» and «${conflictingTalk.title}»!`;
@@ -105,7 +103,6 @@ export class JsonScheduleLoader {
             name: stream.stream_name,
             kind: RoomKind.Auditorium,
             talks
-            conferenceId
         };
     }
 

--- a/src/backends/penta/PentabarfParser.ts
+++ b/src/backends/penta/PentabarfParser.ts
@@ -161,7 +161,6 @@ export class PentabarfParser {
                     name: metadata.name,
                     kind: metadata.kind,
                     talks: new Map(),
-                    conferenceId: "",
                 };
                 const existingAuditorium = this.auditoriums.find(r => r.id === auditorium.id);
                 if (existingAuditorium) {
@@ -188,7 +187,6 @@ export class PentabarfParser {
                         track: pEvent.track,
                         speakers: [],
                         prerecorded: true,
-                        conferenceId: "",
                         auditoriumId: auditorium.id,
                         livestream_endTime: 0,
                         qa_startTime: 0,

--- a/src/backends/penta/PentabarfParser.ts
+++ b/src/backends/penta/PentabarfParser.ts
@@ -161,6 +161,7 @@ export class PentabarfParser {
                     name: metadata.name,
                     kind: metadata.kind,
                     talks: new Map(),
+                    conferenceId: "",
                 };
                 const existingAuditorium = this.auditoriums.find(r => r.id === auditorium.id);
                 if (existingAuditorium) {

--- a/src/commands/BuildCommand.ts
+++ b/src/commands/BuildCommand.ts
@@ -69,8 +69,9 @@ export class BuildCommand implements ICommand {
             roomId,
             `0/${subspacesConfig.length} subspaces have been created`,
         );
-        try {
-            for (const [subspaceId, subspaceConfig] of subspacesConfig) {
+
+        for (const [subspaceId, subspaceConfig] of subspacesConfig) {
+            try {
                 await conference.createSubspace(
                     subspaceId, subspaceConfig.displayName, subspaceConfig.alias
                 );
@@ -81,11 +82,12 @@ export class BuildCommand implements ICommand {
                     statusEventId,
                     `${subspacesCreated}/${subspacesConfig.length} subspaces have been created`,
                 );
+            } catch (error) {
+                LogService.error("BuildCommand", JSON.stringify(error));
+                await client.sendNotice(roomId, `Failed to build subspace '${subspaceId}': ${error.toString()}`)
             }
-        } catch (error) {
-            LogService.error("BuildCommand", JSON.stringify(error));
-            await client.sendNotice(roomId, `Failed to build subspaces: ${error.toString()}`)
         }
+
 
         if (args[0] === "talk") {
             const audId = args[1];

--- a/src/commands/BuildCommand.ts
+++ b/src/commands/BuildCommand.ts
@@ -42,6 +42,7 @@ export class BuildCommand implements ICommand {
         }
 
         if (!conference.isCreated) {
+            await conference.createRootSpace();
             await conference.createDb(backend.conference);
         }
 

--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -24,6 +24,7 @@ export class HelpCommand implements ICommand {
     public async run(conference: Conference, client: MatrixClient, roomId: string, event: any, args: string[]) {
         const htmlHelp = "" +
             "<h1>Conference bot help</h1>" +
+            "Hint: For all commands, instead of !conference you can also use a tab-completed mention pill of the bot's name!\n" +
             "<h4>General:</h4>" +
             "<pre><code>" +
             "!conference help                                          - This menu.\n" +
@@ -58,6 +59,7 @@ export class HelpCommand implements ICommand {
             "<pre><code>" +
             "!conference inviteme &lt;room&gt;         - Asks the bot to invite you to the given room.\n" +
             "!conference inviteto &lt;room&gt; &lt;user&gt;  - Asks the bot to invite the given user to the given room.\n" +
+            "!conference join &lt;room&gt;             - Makes the bot join the given room.\n"
             "!conference copymods &lt;from&gt; &lt;to&gt;    - Copies the moderators from one room to another.\n" +
             "!conference widgets &lt;aud&gt;           - Creates all widgets for the auditorium and its talks.\n" +
             "</code></pre>" +

--- a/src/commands/JoinRoomCommand.ts
+++ b/src/commands/JoinRoomCommand.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ICommand } from "./ICommand";
+import { LogLevel, MatrixClient } from "matrix-bot-sdk";
+import { Conference } from "../Conference";
+import { invitePersonToRoom, ResolvedPersonIdentifier } from "../invites";
+import { logMessage } from "../LogProxy";
+
+export class JoinCommand implements ICommand {
+    public readonly prefixes = ["join"];
+
+    public async run(conference: Conference, client: MatrixClient, roomId: string, event: any, args: string[]) {
+        if (!args.length) {
+            return client.replyNotice(roomId, event, "Please specify a room ID or alias");
+        }
+
+        await client.unstableApis.addReactionToEvent(roomId, event['event_id'], '⌛️');
+
+        await client.joinRoom(args[0], []);
+
+        await client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { FDMCommand } from "./commands/FDMCommand";
 import { IScheduleBackend } from "./backends/IScheduleBackend";
 import { PentaBackend } from "./backends/penta/PentaBackend";
 import { JsonScheduleBackend } from "./backends/json/JsonScheduleBackend";
+import { JoinCommand } from "./commands/JoinRoomCommand";
 
 config.RUNTIME = {
     client: null,
@@ -176,6 +177,7 @@ function registerCommands(conference: Conference, ircBridge: IRCBridge | null) {
         new DevCommand(),
         new PermissionsCommand(),
         new InviteMeCommand(),
+        new JoinCommand(),
         new WidgetsCommand(),
         new RunCommand(),
         new StopCommand(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ function registerCommands(conference: Conference, ircBridge: IRCBridge | null) {
             }
         } catch (e) {
             LogService.error("index", "Error processing command: ", e);
-            return await client.replyNotice(roomId, event, `There was an error processing your command: ${e.message}`);
+            return await client.replyNotice(roomId, event, `There was an error processing your command: ${e?.message}`);
         }
 
         return await client.replyNotice(roomId, event, `Unknown command. Try ${prefixUsed.trim()} help`);

--- a/src/models/Auditorium.ts
+++ b/src/models/Auditorium.ts
@@ -15,28 +15,18 @@ limitations under the License.
 */
 
 import { MatrixClient } from "matrix-bot-sdk";
-import { IStoredAuditorium, RS_STORED_AUDITORIUM } from "./room_state";
 import { Conference } from "../Conference";
 import { MatrixRoom } from "./MatrixRoom";
-import { RSC_AUDITORIUM_ID } from "./room_kinds";
 import { PhysicalRoom } from "./PhysicalRoom";
+import { IAuditorium } from "./schedule";
 
 export class Auditorium extends MatrixRoom implements PhysicalRoom {
-    private storedAud: IStoredAuditorium;
-
-    constructor(roomId: string, client: MatrixClient, conference: Conference) {
+    constructor(roomId: string, private readonly definition: IAuditorium, client: MatrixClient, conference: Conference) {
         super(roomId, client, conference);
     }
 
-    public async getDefinition(): Promise<IStoredAuditorium> {
-        if (this.storedAud) {
-            return this.storedAud;
-        }
-
-        const createEvent = await this.client.getRoomStateEvent(this.roomId, "m.room.create", "");
-        const audId = createEvent[RSC_AUDITORIUM_ID];
-        this.storedAud = await this.client.getRoomStateEvent(this.roomId, RS_STORED_AUDITORIUM, audId);
-        return this.storedAud;
+    public async getDefinition(): Promise<IAuditorium> {
+        return this.definition;
     }
 
     public async getName(): Promise<string> {
@@ -58,7 +48,7 @@ export class Auditorium extends MatrixRoom implements PhysicalRoom {
 
 // It's the same but different
 export class AuditoriumBackstage extends Auditorium {
-    constructor(roomId: string, client: MatrixClient, conference: Conference) {
-        super(roomId, client, conference);
+    constructor(roomId: string, definition: IAuditorium, client: MatrixClient, conference: Conference) {
+        super(roomId, definition, client, conference);
     }
 }

--- a/src/models/Auditorium.ts
+++ b/src/models/Auditorium.ts
@@ -40,10 +40,6 @@ export class Auditorium extends MatrixRoom implements PhysicalRoom {
     public async getId(): Promise<string> {
         return (await this.getDefinition()).id;
     }
-
-    public async getConferenceId(): Promise<string> {
-        return (await this.getDefinition()).conferenceId;
-    }
 }
 
 // It's the same but different

--- a/src/models/InterestRoom.ts
+++ b/src/models/InterestRoom.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { MatrixClient } from "matrix-bot-sdk";
 import { Conference } from "../Conference";
 import { MatrixRoom } from "./MatrixRoom";
-import { deprefix } from "../backends/PentabarfParser";
+import { deprefix } from "../backends/penta/PentabarfParser";
 import { PhysicalRoom } from "./PhysicalRoom";
 
 /**

--- a/src/models/MatrixRoom.ts
+++ b/src/models/MatrixRoom.ts
@@ -25,11 +25,6 @@ export class MatrixRoom {
     constructor(public readonly roomId: string, protected client: MatrixClient, protected conference: Conference) {
     }
 
-    public async addDirectChild(roomId: string) {
-        const state = makeChildRoom(roomId);
-        await this.client.sendStateEvent(this.roomId, state.type, state.state_key, state.content);
-    }
-
     public async getAssociatedSpace(): Promise<Space> {
         if (this.space) {
             return this.space;

--- a/src/models/MatrixRoom.ts
+++ b/src/models/MatrixRoom.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { LogService, MatrixClient, Space } from "matrix-bot-sdk";
-import { makeChildRoom, RS_STORED_SPACE } from "./room_state";
+import { RS_ASSOCIATED_SPACE } from "./room_state";
 import { Conference } from "../Conference";
 
 export class MatrixRoom {
@@ -30,11 +30,11 @@ export class MatrixRoom {
         await this.client.sendStateEvent(this.roomId, state.type, state.state_key, state.content);
     }
 
-    public async getSpace(): Promise<Space> {
+    public async getAssociatedSpace(): Promise<Space> {
         if (this.space) {
             return this.space;
         }
-        const spaceState = await this.client.getRoomStateEvent(this.roomId, RS_STORED_SPACE, "");
+        const spaceState = await this.client.getRoomStateEvent(this.roomId, RS_ASSOCIATED_SPACE, "");
         this.space = await this.client.getSpace(spaceState.roomId);
         return this.space;
     }

--- a/src/models/Talk.ts
+++ b/src/models/Talk.ts
@@ -36,10 +36,6 @@ export class Talk extends MatrixRoom {
         return (await this.getDefinition()).id;
     }
 
-    public async getConferenceId(): Promise<string> {
-        return (await this.getDefinition()).conferenceId;
-    }
-
     public async getAuditoriumId(): Promise<string> {
         return (await this.getDefinition()).auditoriumId;
     }

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -17,10 +17,6 @@ limitations under the License.
 import {
     RS_CHILD_ROOM,
     RS_PARENT_ROOM,
-    RS_STORED_CONFERENCE,
-    RS_STORED_PERSON,
-    RS_STORED_AUDITORIUM,
-    RS_STORED_TALK
 } from "./room_state";
 import config from "../config";
 
@@ -44,10 +40,6 @@ export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = {
         "m.room.name": 100,
         "m.room.power_levels": 100,
         "m.room.topic": 100,
-        [RS_STORED_CONFERENCE]: 100,
-        [RS_STORED_PERSON]: 100,
-        [RS_STORED_AUDITORIUM]: 100,
-        [RS_STORED_TALK]: 100,
         [RS_PARENT_ROOM]: 100,
         [RS_CHILD_ROOM]: 100,
         "org.matrix.msc1772.room.parent": 100,
@@ -64,24 +56,23 @@ export const PRIVATE_ROOM_POWER_LEVELS_TEMPLATE = {
     invite: 0,
 };
 
-export const RSC_ROOM_KIND_FLAG = "org.matrix.confbot.kind";
+/**
+ * Key in a RS_LOCATOR event that identifies what kind of room it is.
+ * Not namespaced because the event type is already privately namespaced for the bot.
+ */
+export const RSC_ROOM_KIND_FLAG = "kind";
 export enum RoomKind {
     /**
      * The value is a misnomer: 'conference' is the kind of the conference's *database* room.
      * This is *not* the public space for the conference.
      */
     ConferenceDb = "conference",
+    ConferenceSpace = "conference_space", // TODO
     Auditorium = "auditorium",
     AuditoriumBackstage = "auditorium_backstage",
     Talk = "talk",
     SpecialInterest = "other",
 }
-export const ALL_USEFUL_ROOM_KINDS = [
-    RoomKind.Auditorium,
-    RoomKind.AuditoriumBackstage,
-    RoomKind.Talk,
-    RoomKind.SpecialInterest,
-];
 
 /**
  * Type of state event used to identify rooms that the bot has created.

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -42,8 +42,8 @@ export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = {
         "m.room.topic": 100,
         [RS_PARENT_ROOM]: 100,
         [RS_CHILD_ROOM]: 100,
-        "org.matrix.msc1772.room.parent": 100,
-        "org.matrix.msc1772.space.child": 100,
+        "m.room.parent": 100, // TODO is this stabilised yet?
+        "m.space.child": 100,
     },
     users: {
         [config.moderatorUserId]: 100,

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -14,10 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-    RS_CHILD_ROOM,
-    RS_PARENT_ROOM,
-} from "./room_state";
 import config from "../config";
 
 export const KickPowerLevel = 50;
@@ -40,9 +36,7 @@ export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = {
         "m.room.name": 100,
         "m.room.power_levels": 100,
         "m.room.topic": 100,
-        [RS_PARENT_ROOM]: 100,
-        [RS_CHILD_ROOM]: 100,
-        "m.room.parent": 100, // TODO is this stabilised yet?
+        "m.space.parent": 100,
         "m.space.child": 100,
     },
     users: {
@@ -79,10 +73,10 @@ export enum RoomKind {
  */
 export const RS_LOCATOR = "org.matrix.confbot.locator";
 
-export const RSC_CONFERENCE_ID = "org.matrix.confbot.conference";
-export const RSC_AUDITORIUM_ID = "org.matrix.confbot.auditorium";
-export const RSC_TALK_ID = "org.matrix.confbot.talk";
-export const RSC_SPECIAL_INTEREST_ID = "org.matrix.confbot.interest";
+export const RSC_CONFERENCE_ID = "conferenceId";
+export const RSC_AUDITORIUM_ID = "auditoriumId";
+export const RSC_TALK_ID = "talkId";
+export const RSC_SPECIAL_INTEREST_ID = "interestId";
 
 export const CONFERENCE_ROOM_CREATION_TEMPLATE = {
     preset: 'private_chat',

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -79,6 +79,11 @@ export const ALL_USEFUL_ROOM_KINDS = [
     RoomKind.SpecialInterest,
 ];
 
+/**
+ * Type of state event used to identify rooms that the bot has created.
+ */
+export const RS_LOCATOR = "org.matrix.confbot.locator";
+
 export const RSC_CONFERENCE_ID = "org.matrix.confbot.conference";
 export const RSC_AUDITORIUM_ID = "org.matrix.confbot.auditorium";
 export const RSC_TALK_ID = "org.matrix.confbot.talk";

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -66,7 +66,11 @@ export const PRIVATE_ROOM_POWER_LEVELS_TEMPLATE = {
 
 export const RSC_ROOM_KIND_FLAG = "org.matrix.confbot.kind";
 export enum RoomKind {
-    Conference = "conference",
+    /**
+     * The value is a misnomer: 'conference' is the kind of the conference's *database* room.
+     * This is *not* the public space for the conference.
+     */
+    ConferenceDb = "conference",
     Auditorium = "auditorium",
     AuditoriumBackstage = "auditorium_backstage",
     Talk = "talk",
@@ -97,7 +101,7 @@ export const CONFERENCE_ROOM_CREATION_TEMPLATE = {
         {type: "m.room.history_visibility", state_key: "", content: {history_visibility: "shared"}},
     ],
     creation_content: {
-        [RSC_ROOM_KIND_FLAG]: RoomKind.Conference,
+        [RSC_ROOM_KIND_FLAG]: RoomKind.ConferenceDb,
     },
 };
 

--- a/src/models/room_state.ts
+++ b/src/models/room_state.ts
@@ -86,13 +86,23 @@ export function makeChildRoom(roomId: string): IStateEvent<IChildRoom> {
     };
 }
 
-export const RS_STORED_SPACE = "org.matrix.confbot.space";
-export interface IStoredSpace {
+/**
+ * Associated space: a canonical definition of which space is 'associated' with this room.
+ *
+ * List of valid use cases:
+ * - In an auditorium room, points to the auditorium's space.
+ * - TODO more?
+ *
+ * Begrudgingly m.space.parent isn't very useful in these scenarios because the state key is the parent of the room
+ * and they're not easily canonical. (This can probably be worked around, but I can only rework so much at once!)
+ */
+export const RS_ASSOCIATED_SPACE = "org.matrix.confbot.space";
+export interface IAssociatedSpace {
     roomId: string;
 }
-export function makeStoredSpace(roomId: string): IStateEvent<IStoredSpace> {
+export function makeAssociatedSpace(roomId: string): IStateEvent<IAssociatedSpace> {
     return {
-        type: RS_STORED_SPACE,
+        type: RS_ASSOCIATED_SPACE,
         state_key: "",
         content: {roomId: roomId},
     };

--- a/src/models/room_state.ts
+++ b/src/models/room_state.ts
@@ -62,30 +62,6 @@ export function makeStoredPersonOverride(person: IPerson): IStateEvent<IPerson> 
     };
 }
 
-export const RS_PARENT_ROOM = "org.matrix.confbot.parent";
-export interface IParentRoom {
-    roomId: string;
-}
-export function makeParentRoom(roomId: string): IStateEvent<IParentRoom> {
-    return {
-        type: RS_PARENT_ROOM,
-        state_key: "",
-        content: {roomId: roomId},
-    };
-}
-
-export const RS_CHILD_ROOM = "org.matrix.confbot.child";
-export interface IChildRoom {
-    roomId: string;
-}
-export function makeChildRoom(roomId: string): IStateEvent<IChildRoom> {
-    return {
-        type: RS_CHILD_ROOM,
-        state_key: roomId,
-        content: {roomId: roomId},
-    };
-}
-
 /**
  * Associated space: a canonical definition of which space is 'associated' with this room.
  *

--- a/src/models/room_state.ts
+++ b/src/models/room_state.ts
@@ -54,7 +54,17 @@ export function makeStoredTalk(talk: ITalk): IStateEvent<ITalk> {
 }
 
 export const RS_STORED_PERSON = "org.matrix.confbot.person.v2";
-export function makeStoredPerson(person: IPerson): IStateEvent<IPerson> {
+/**
+ * This allows us to create a state event, to be stored in the Database room,
+ * which represents an override of a person from their underlying representation in the schedule.
+ *
+ * This is used when a person accepts an e-mail invite and therefore we learn of their
+ * Matrix ID, despite them not having one in the schedule.
+ *
+ * Note that the returned object contains private information and as such must not be
+ * stored in any public rooms.
+ */
+export function makeStoredPersonOverride(person: IPerson): IStateEvent<IPerson> {
     return {
         type: RS_STORED_PERSON,
         state_key: person.id.toString(),

--- a/src/models/room_state.ts
+++ b/src/models/room_state.ts
@@ -101,10 +101,10 @@ export function makeStoredSpace(roomId: string): IStateEvent<IStoredSpace> {
 /**
  * See RS_LOCATOR.
  */
-export type ILocator = IDbLocator | ITalkLocator | IAuditoriumLocator | IInterestLocator
+export type ILocator = IConferenceLocator | ITalkLocator | IAuditoriumLocator | IInterestLocator
 
-export interface IDbLocator {
-    [RSC_ROOM_KIND_FLAG]: RoomKind.ConferenceDb;
+export interface IConferenceLocator {
+    [RSC_ROOM_KIND_FLAG]: RoomKind.ConferenceDb | RoomKind.ConferenceSpace;
     conferenceId: string;
 }
 export interface ITalkLocator {
@@ -123,8 +123,18 @@ export interface IInterestLocator {
     interestId: InterestId;
 }
 
+export function makeRootSpaceLocator(conferenceId: string): IStateEvent<IConferenceLocator> {
+    return {
+        type: RS_LOCATOR,
+        state_key: "",
+        content: {
+            [RSC_ROOM_KIND_FLAG]: RoomKind.ConferenceSpace,
+            conferenceId,
+        },
+    };
+}
 
-export function makeDbLocator(conferenceId: string): IStateEvent<IDbLocator> {
+export function makeDbLocator(conferenceId: string): IStateEvent<IConferenceLocator> {
     return {
         type: RS_LOCATOR,
         state_key: "",

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -69,6 +69,10 @@ export interface IAuditorium {
     name: string;
     kind: RoomKind;
     talks: Map<TalkId, ITalk>;
+    /**
+     * ID of the conference that this talk belongs to.
+     */
+    conferenceId: string;
 }
 
 export interface IConference {

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -51,10 +51,6 @@ export interface ITalk {
     speakers: IPerson[];
     prerecorded: boolean;
     /**
-     * ID of the conference that this talk belongs to.
-     */
-    conferenceId: string;
-    /**
      * ID of the auditorium that this talk belongs to.
      */
     auditoriumId: string;
@@ -69,10 +65,6 @@ export interface IAuditorium {
     name: string;
     kind: RoomKind;
     talks: Map<TalkId, ITalk>;
-    /**
-     * ID of the conference that this talk belongs to.
-     */
-    conferenceId: string;
 }
 
 export interface IConference {


### PR DESCRIPTION
This notably lets us re-use existing rooms if desired.
I also rip out the parts that store the schedule in the matrix room. These make it unnecessarily confusing as we have 2 sources of truth and provided privacy leaks where some of the information was private (e.g. speaker e-mail addresses).

Some exceptions — room state we keep around:
- new locator, which just serves to correlate rooms with what's in the schedule
- person *overrides* (after they accept an e-mail invite) — I've rebranded these as *overrides* to try to make it more obvious why we have them and how they interact with the ones in the underlying schedule.




<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:wedf/a
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#130|Allow disabling IRC bridge by not configuring one, to prevent crash|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/130?label=Pending)|-|
|#131|Fix !schedule view falling over with long schedules|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/131?label=Pending)|#130|
|#133|*(Draft) Try to disconnect the Conference bot from being so reliant on Pentabarf (best effort)*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/133?label=Pending)|#131|
|#132|*(Draft) Add a JSON schedule loader*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/132?label=Pending)|#133|
|#134|*(Draft) Fix some misc bugs*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/134?label=Pending)|#132|
|#135|*(Draft) Disable features relating to Q&A if desired*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/135?label=Pending)|#134|
|#136|*(Draft) Refactor the backends to be called backends*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/136?label=Pending)|#135|
|#137|👉 *(Draft) Use a custom 'locator' state event rather than `m.room.create`.*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/137?label=Pending)|#136|
|#138|*(Draft) Add a schedule cache as a fallback for if the original schedule goes offline*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/138?label=Pending)|#137|
|#139|*(Draft) Add a status command to get some information about the bot and its situation*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/139?label=Pending)|#138|
<!---GHSTACKCLOSE-->



