### PR TITLE
Add a schedule cache as a fallback for if the original schedule goes offline [rei:wedf/a]

### DIFF
--- a/src/backends/IScheduleBackend.ts
+++ b/src/backends/IScheduleBackend.ts
@@ -20,6 +20,14 @@ export interface IScheduleBackend {
     refresh(): Promise<void>;
 
     /**
+     * Returns true iff the current schedule was loaded from cache, rather than from the intended source.
+     * This happens if there was a problem loading the schedule from the intended source for some reason.
+     * The intention of exposing this information is that it allows us to send a notice into the
+     * management room, so that the admin knows what's going on.
+     */
+    wasLoadedFromCache(): boolean;
+
+    /**
      * Raw view of the conference.
      * Prefer to use the `talks`, `auditoriums` and `interestRooms` properties instead of the conference.
      */

--- a/src/backends/json/JsonScheduleBackend.ts
+++ b/src/backends/json/JsonScheduleBackend.ts
@@ -1,16 +1,18 @@
-import { readFile } from "fs";
-import { IJsonScheduleBackendConfig } from "../../config";
+import { readFile, writeFile, rename } from "fs";
+import config, { IJsonScheduleBackendConfig } from "../../config";
 import { IConference, ITalk, IAuditorium, IInterestRoom } from "../../models/schedule";
 import { AuditoriumId, InterestId, IScheduleBackend, TalkId } from "../IScheduleBackend";
 import { JsonScheduleLoader } from "./JsonScheduleLoader";
 import * as fetch from "node-fetch";
+import * as path from "path";
+import { LogService } from "matrix-bot-sdk";
 
 /**
  * Reads a JSON file from disk.
  */
  function readJsonFileAsync(path: string): Promise<object> {
     return new Promise((resolve, reject) => {
-        readFile(path, {}, (err, buf: string) => {
+        readFile(path, {encoding: 'utf-8'}, (err, buf: string) => {
             if (err) {
                 reject(err);
             } else {
@@ -24,31 +26,93 @@ import * as fetch from "node-fetch";
     });
 }
 
+/**
+ * Writes a JSON file to disk.
+ */
+function writeJsonFileAsync(path: string, data: object): Promise<void> {
+    return new Promise((resolve, reject) => {
+        writeFile(path, JSON.stringify(data), (err) => {
+            if (err) {
+                reject(err);
+            } else {
+                try {
+                    resolve();
+                } catch (err) {
+                    reject(err);
+                }
+            }
+        })
+    });
+}
+
 export class JsonScheduleBackend implements IScheduleBackend {
-    constructor(private loader: JsonScheduleLoader, private cfg: IJsonScheduleBackendConfig) {
+    constructor(private loader: JsonScheduleLoader, private cfg: IJsonScheduleBackendConfig, private wasFromCache: boolean) {
 
     }
 
-    private static async loadConferenceFromCfg(cfg: IJsonScheduleBackendConfig): Promise<JsonScheduleLoader> {
+    wasLoadedFromCache(): boolean {
+        return this.wasFromCache;
+    }
+
+    private static async loadConferenceFromCfg(cfg: IJsonScheduleBackendConfig, allowUseCache: boolean): Promise<{loader: JsonScheduleLoader, cached: boolean}> {
         let jsonDesc;
-        if (cfg.scheduleDefinition.startsWith("http")) {
-            // Fetch the JSON track over the network
-            jsonDesc = await fetch(cfg.scheduleDefinition).then(r => r.json());
-        } else {
-            // Load the JSON from disk
-            jsonDesc = await readJsonFileAsync(cfg.scheduleDefinition);
+        let cached = false;
+
+        const cachedSchedulePath = path.join(config.dataPath, 'cached_schedule.json');
+
+        try {
+            if (cfg.scheduleDefinition.startsWith("http")) {
+                // Fetch the JSON track over the network
+                jsonDesc = await fetch(cfg.scheduleDefinition).then(r => r.json());
+            } else {
+                // Load the JSON from disk
+                jsonDesc = await readJsonFileAsync(cfg.scheduleDefinition);
+            }
+
+            // Save a cached copy.
+            // Do it atomically so that there's very little chance of anything going wrong: write to a file first, then move into place.
+            await writeJsonFileAsync(cachedSchedulePath + '.part', jsonDesc);
+            rename(cachedSchedulePath + '.part', cachedSchedulePath, (err) => {
+                if (err) {
+                    LogService.error("JsonScheduleBackend", `Failed to save cached copy of schedule: ${err}`)
+                }
+            });
+
+        } catch (e) {
+            // Fallback to cache — only if allowed
+            if (! allowUseCache) throw e;
+
+            cached = true;
+
+            LogService.error("JsonScheduleBackend", "Unable to load JSON schedule, will use cached copy if available.", e.body ?? e);
+            try {
+                jsonDesc = await readJsonFileAsync(cachedSchedulePath);
+            } catch (e) {
+                if (e.code === 'ENOENT') {
+                    // No file
+                    LogService.error("JsonScheduleBackend", "Double fault: Unable to load schedule and unable to load cached schedule (cached file doesn't exist)");
+                } else if (e instanceof SyntaxError) {
+                    LogService.error("JsonScheduleBackend", "Double fault: Unable to load schedule and unable to load cached schedule (cached file has invalid JSON)");
+                } else {
+                    LogService.error("JsonScheduleBackend", "Double fault: Unable to load schedule and unable to load cached schedule: ", e);
+                }
+
+                throw "Double fault whilst trying to load JSON schedule";
+            }
         }
 
-        return new JsonScheduleLoader(jsonDesc);
+        return {loader: new JsonScheduleLoader(jsonDesc), cached};
     }
 
     static async new(cfg: IJsonScheduleBackendConfig): Promise<JsonScheduleBackend> {
-        const loader = await JsonScheduleBackend.loadConferenceFromCfg(cfg);
-        return new JsonScheduleBackend(loader, cfg);
+        const loader = await JsonScheduleBackend.loadConferenceFromCfg(cfg, true);
+        return new JsonScheduleBackend(loader.loader, cfg, loader.cached);
     }
 
     async refresh(): Promise<void> {
-        this.loader = await JsonScheduleBackend.loadConferenceFromCfg(this.cfg);
+        this.loader = (await JsonScheduleBackend.loadConferenceFromCfg(this.cfg, false)).loader;
+        // If we managed to load anything, this isn't from the cache anymore.
+        this.wasFromCache = false;
     }
 
     get conference(): IConference {

--- a/src/backends/penta/PentaBackend.ts
+++ b/src/backends/penta/PentaBackend.ts
@@ -45,6 +45,11 @@ export class PentaBackend implements IScheduleBackend {
         this.interestRooms = interestRooms;
     }
 
+    wasLoadedFromCache(): boolean {
+        // Penta backend doesn't support using a cache.
+        return false;
+    }
+
     static async new(cfg: IPentaScheduleBackendConfig): Promise<PentaBackend> {
         const xml = await fetch(cfg.scheduleDefinition).then(r => r.text());
         const parsed = new PentabarfParser(xml);

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,13 @@ let userId;
         );
     }
 
+    if (backend.wasLoadedFromCache()) {
+        await client.sendHtmlText(config.managementRoom, "" +
+            "<h4>⚠ Cached schedule in use ⚠</h4>" +
+            "<p>@room ⚠ The bot failed to load the schedule properly and a cached copy is being used.</p>"
+        );
+    }
+
     // Load the previous room scoreboards. This has to happen before we start syncing, otherwise
     // new scoreboard changes will get lost. The `MatrixClient` resumes syncing from where it left
     // off, so events will only be missed if the bot dies while processing them.


### PR DESCRIPTION
Now that we rely on the schedule being available on every startup (not just for building), I propose we add a caching mechanism so that the bot can handle a single fault in loading the cache from the original source.

<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:wedf/a
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#130|Allow disabling IRC bridge by not configuring one, to prevent crash|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/130?label=Pending)|-|
|#131|Fix !schedule view falling over with long schedules|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/131?label=Pending)|#130|
|#133|*(Draft) Try to disconnect the Conference bot from being so reliant on Pentabarf (best effort)*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/133?label=Pending)|#131|
|#132|*(Draft) Add a JSON schedule loader*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/132?label=Pending)|#133|
|#134|*(Draft) Fix some misc bugs*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/134?label=Pending)|#132|
|#135|*(Draft) Disable features relating to Q&A if desired*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/135?label=Pending)|#134|
|#136|*(Draft) Refactor the backends to be called backends*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/136?label=Pending)|#135|
|#137|*(Draft) Use a custom 'locator' state event rather than `m.room.create`.*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/137?label=Pending)|#136|
|#138|👉 *(Draft) Add a schedule cache as a fallback for if the original schedule goes offline*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/138?label=Pending)|#137|
|#139|*(Draft) Add a status command to get some information about the bot and its situation*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/139?label=Pending)|#138|
<!---GHSTACKCLOSE-->

