### PR TITLE
Allow enabling Q&A for only select auditoriums [rei:fd]

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -236,6 +236,10 @@ conference:
     # trimmed when naming the room (unless an override is present).
     auditoriumRooms: ["D."]
 
+    # Prefixes for the auditorium rooms that have Q&A sessions.
+    # Rooms outside of these prefixes will not have Q&A sessions.
+    qaAuditoriumRooms: ["D."]
+
     # The prefixes for the rooms listed in the pentabarf definition which
     # describe the rooms that are 'special interest' rooms. The prefixes will
     # be trimmed when naming the room (unless an override is present).

--- a/src/__tests__/backends/penta/PentabarfParser.test.ts
+++ b/src/__tests__/backends/penta/PentabarfParser.test.ts
@@ -11,6 +11,10 @@ const prefixConfig: IPrefixConfig = {
 
     auditoriumRooms: [
         "A.",
+        "AQ.",
+    ],
+    qaAuditoriumRooms: [
+        "AQ.",
     ],
     interestRooms: [
         "X."

--- a/src/__tests__/backends/penta/__snapshots__/PentabarfParser.test.ts.snap
+++ b/src/__tests__/backends/penta/__snapshots__/PentabarfParser.test.ts.snap
@@ -15,7 +15,7 @@ exports[`parsing pentabarf XML: overview: auditoriums 1`] = `
         "id": "E001",
         "livestream_endTime": 0,
         "prerecorded": true,
-        "qa_startTime": 0,
+        "qa_startTime": null,
         "slug": "testcon_opening_remarks",
         "speakers": [
           {
@@ -59,7 +59,7 @@ exports[`parsing pentabarf XML: overview: conference 1`] = `
           "id": "E001",
           "livestream_endTime": 0,
           "prerecorded": true,
-          "qa_startTime": 0,
+          "qa_startTime": null,
           "slug": "testcon_opening_remarks",
           "speakers": [
             {
@@ -120,7 +120,7 @@ exports[`parsing pentabarf XML: overview: talks 1`] = `
     "id": "E001",
     "livestream_endTime": 0,
     "prerecorded": true,
-    "qa_startTime": 0,
+    "qa_startTime": null,
     "slug": "testcon_opening_remarks",
     "speakers": [
       {

--- a/src/backends/penta/PentabarfParser.ts
+++ b/src/backends/penta/PentabarfParser.ts
@@ -169,6 +169,8 @@ export class PentabarfParser {
                     this.auditoriums.push(auditorium);
                 }
 
+                const qaEnabled = prefixConfig.qaAuditoriumRooms.find(p => auditorium.name.startsWith(p)) !== undefined;
+
                 for (const pEvent of arrayLike(pRoom.event)) {
                     if (!pEvent) continue;
 
@@ -189,7 +191,8 @@ export class PentabarfParser {
                         prerecorded: true,
                         auditoriumId: auditorium.id,
                         livestream_endTime: 0,
-                        qa_startTime: 0,
+                        // 0 is populated later by consulting the PentaDb.
+                        qa_startTime: qaEnabled ? 0 : null,
                     };
                     const existingTalk = this.talks.find(e => e.id === talk.id);
                     if (existingTalk) {

--- a/src/backends/penta/PentabarfParser.ts
+++ b/src/backends/penta/PentabarfParser.ts
@@ -169,7 +169,7 @@ export class PentabarfParser {
                     this.auditoriums.push(auditorium);
                 }
 
-                const qaEnabled = prefixConfig.qaAuditoriumRooms.find(p => auditorium.name.startsWith(p)) !== undefined;
+                const qaEnabled = prefixConfig.qaAuditoriumRooms.find(p => auditorium.id.startsWith(p)) !== undefined;
 
                 for (const pEvent of arrayLike(pRoom.event)) {
                     if (!pEvent) continue;

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,7 @@ interface IConfig {
 
 export interface IPrefixConfig {
     auditoriumRooms: string[];
+    qaAuditoriumRooms: string[];
     interestRooms: string[];
     aliases: string;
     suffixes: {


### PR DESCRIPTION
Fixes #119.




<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:fd
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#144|Add tests for the PentabarfParser|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/144?label=Pending)|-|
|#145|👉 Allow enabling Q&A for only select auditoriums|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/145?label=Pending)|#144|
|#146|Hydrate talks from the Penta database|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/146?label=Pending)|#145|
|#147|Add the moderator to created sub-spaces automatically|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/147?label=Pending)|#146|
|#148|Set power level for appservice user when doing `plumb all`.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/148?label=Pending)|#147|
|#149|Throw error on duplicate talk IDs|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/149?label=Pending)|#148|
|#150|*(Draft) Allow inviting users to one of a handful of 'room groups'*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/150?label=Pending)|#149|
<!---GHSTACKCLOSE-->




