### PR TITLE
Add the moderator to created sub-spaces automatically [rei:fd]

### DIFF
--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -392,12 +392,17 @@ export class Conference {
                 isPublic: true,
                 localpart: "space-" + config.conference.prefixes.aliases + aliasLocalpart,
                 name: name,
+                invites: [config.moderatorUserId],
             });
             this.subspaces[subspaceId] = subspace;
 
             await this.client.sendStateEvent(this.dbRoom.roomId, RS_STORED_SUBSPACE, subspaceId, {
                 roomId: subspace.roomId,
             } as IStoredSubspace);
+
+            // Grants PL100 to the moderator in the subspace.
+            // We can't do this directly with `createSpace` unfortunately, as we could for plain rooms.
+            await this.client.setUserPowerLevel(config.moderatorUserId, subspace.roomId, 100);
         } else {
             subspace = this.subspaces[subspaceId];
         }


### PR DESCRIPTION
Fixes #96.




<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:fd
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#144|Add tests for the PentabarfParser|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/144?label=Pending)|-|
|#145|Allow enabling Q&A for only select auditoriums|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/145?label=Pending)|#144|
|#146|Hydrate talks from the Penta database|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/146?label=Pending)|#145|
|#147|👉 Add the moderator to created sub-spaces automatically|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/147?label=Pending)|#146|
|#148|Set power level for appservice user when doing `plumb all`.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/148?label=Pending)|#147|
|#149|Throw error on duplicate talk IDs|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/149?label=Pending)|#148|
|#150|*(Draft) Allow inviting users to one of a handful of 'room groups'*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/150?label=Pending)|#149|
<!---GHSTACKCLOSE-->




