### PR TITLE
Throw error on duplicate talk IDs [rei:fd]

### DIFF
--- a/src/__tests__/backends/penta/PentabarfParser.test.ts
+++ b/src/__tests__/backends/penta/PentabarfParser.test.ts
@@ -46,3 +46,12 @@ test('parsing pentabarf XML: overview', () => {
     //      using the PentaDb afterwards.
     expect(p.talks).toMatchSnapshot("talks");
 });
+
+
+test('duplicate events lead to errors', () => {
+    const xml = fs.readFileSync(path.join(__dirname, "pentabarf03_duplicate_talk.xml"), 'utf8');
+
+    expect(() => new PentabarfParser(xml, prefixConfig)).toThrow(
+        "Auditorium A.01 (Someroom): Talk E001: this talk already exists and is defined a second time."
+    );
+});

--- a/src/__tests__/backends/penta/pentabarf03_duplicate_talk.xml
+++ b/src/__tests__/backends/penta/pentabarf03_duplicate_talk.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schedule>
+  <conference>
+    <title>Testcon01</title>
+    <subtitle/>
+  </conference>
+  <!-- Test https://github.com/matrix-org/conference-bot/issues/1 -->
+  <day index="1" date="2023-02-04">
+    <room name="A.01 (Someroom)">
+      <event id="E001">
+        <start>09:00</start>
+        <duration>00:15</duration>
+        <room>A.01 (Someroom)</room>
+        <slug>testcon_opening_remarks</slug>
+        <title>Testcon01: Opening Remarks</title>
+        <track>Track01</track>
+        <type>devroom</type>
+        <abstract>
+          &lt;p&gt;Opening remarks&lt;/p&gt;
+        </abstract>
+        <persons>
+          <person id="9012">John Teststone</person>
+          <person id="90367">Evå 完牲 Exampleson</person> <!-- seemed wise to test some Unicode -->
+        </persons>
+      </event>
+    </room>
+  </day>
+  <day index="1" date="2023-02-05">
+    <room name="A.01 (Someroom)">
+      <event id="E001">
+        <start>09:00</start>
+        <duration>00:15</duration>
+        <room>A.01 (Someroom)</room>
+        <slug>testcon_opening_remarks</slug>
+        <title>Testcon01: Opening Remarks for the second day</title>
+        <track>Track01</track>
+        <type>devroom</type>
+        <abstract>
+          &lt;p&gt;Opening remarks&lt;/p&gt;
+        </abstract>
+        <persons>
+          <person id="9012">John Teststone</person>
+        </persons>
+      </event>
+    </room>
+  </day>
+</schedule>

--- a/src/backends/penta/PentabarfParser.ts
+++ b/src/backends/penta/PentabarfParser.ts
@@ -201,7 +201,11 @@ export class PentabarfParser {
                         this.talks.push(talk);
                     }
 
-                    if (!auditorium.talks.has(talk.id)) auditorium.talks.set(talk.id, talk);
+                    if (auditorium.talks.has(talk.id)) {
+                        throw new Error(`Auditorium ${auditorium.id}: Talk ${talk.id}: this talk already exists and is defined a second time.`);
+                    } else {
+                        auditorium.talks.set(talk.id, talk);
+                    }
 
                     for (const pPerson of arrayLike(pEvent.persons?.person)) {
                         if (!pPerson) continue;


### PR DESCRIPTION
Fixes #1

<!---GHSTACKOPEN-->
### Stacked PR Chain: rei:fd
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#144|Add tests for the PentabarfParser|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/144?label=Pending)|-|
|#145|Allow enabling Q&A for only select auditoriums|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/145?label=Pending)|#144|
|#146|Hydrate talks from the Penta database|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/146?label=Pending)|#145|
|#147|Add the moderator to created sub-spaces automatically|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/147?label=Pending)|#146|
|#148|Set power level for appservice user when doing `plumb all`.|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/148?label=Pending)|#147|
|#149|👉 Throw error on duplicate talk IDs|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/149?label=Pending)|#148|
|#150|*(Draft) Allow inviting users to one of a handful of 'room groups'*|![](https://img.shields.io/github/pulls/detail/state/matrix-org/conference-bot/150?label=Pending)|#149|
<!---GHSTACKCLOSE-->

