### PR TITLE
Allow a list of alias prefixes

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -255,8 +255,11 @@ conference:
     nameOverrides:
       #"D.example": "example-room"
 
-    # The prefix to apply to all generated room aliases.
-    aliases: ""
+    # The prefix(es) to apply to all generated room aliases.
+    # If there are multiple of them, each one is applied separately (so the room has more and more aliases).
+    # (Don't forget an empty string in the list if you want an unprefixed alias for your rooms!)
+    aliases:
+      - ""
 
     # The alias suffixes to apply for certain prefixes of rooms
     suffixes:

--- a/src/__tests__/utils/aliases.test.ts
+++ b/src/__tests__/utils/aliases.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@jest/globals";
+import { applyAllAliasPrefixes } from "../../utils/aliases";
+
+test("applyAllAliasPrefixes", async () => {
+    expect(applyAllAliasPrefixes("wombat", [])).toEqual(["wombat"]);
+    expect(applyAllAliasPrefixes("wombat", [""])).toEqual(["wombat"]);
+    expect(applyAllAliasPrefixes("wombat", "")).toEqual(["wombat"]);
+
+    expect(applyAllAliasPrefixes("wombat", "a-")).toEqual(["a-wombat"]);
+    expect(applyAllAliasPrefixes("wombat", ["a-"])).toEqual(["a-wombat"]);
+
+    expect(applyAllAliasPrefixes("wombat", ["a-", "b-"])).toEqual(["a-wombat", "b-wombat"]);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,7 +89,7 @@ export interface IPrefixConfig {
     qaAuditoriumRooms: string[];
     physicalAuditoriumRooms: string[];
     interestRooms: string[];
-    aliases: string;
+    aliases: string | string[];
     suffixes: {
         [prefix: string]: string;
     };

--- a/src/utils/aliases.ts
+++ b/src/utils/aliases.ts
@@ -65,8 +65,13 @@ export function makeLocalpart(localpart: string, identifier?: string): string {
     return applySuffixRules(localpart, identifier, config.conference.prefixes.suffixes);
 }
 
-export async function assignAliasVariations(client: MatrixClient, roomId: string, localpart: string, identifier?: string): Promise<void> {
-    const localparts = calculateAliasVariations(localpart, identifier);
+export async function assignAliasVariations(client: MatrixClient, roomId: string, origLocalparts: string[], identifier?: string): Promise<void> {
+    const localparts = new Set<string>();
+    for (const origLocalpart of origLocalparts) {
+        for (const localpart of calculateAliasVariations(origLocalpart, identifier)) {
+            localparts.add(localpart);
+        }
+    }
     for (const lp of localparts) {
         await safeAssignAlias(client, roomId, lp);
     }

--- a/src/utils/aliases.ts
+++ b/src/utils/aliases.ts
@@ -157,3 +157,23 @@ export async function addAndDeleteManagedAliases(client: MatrixClient, roomId: s
 export function slugify(input: string): string {
     return input.toLowerCase().replace(/[^0-9a-z-_.]+/g, "_");
 }
+
+/**
+ * Given an unprefixed alias name and the configured list of alias prefixes, returns a list of all prefixed aliases.
+ * @param name Unprefixed alias name.
+ * @param prefixes List of (or single) string prefix(es). Likely to be taken from `IPrefixConfig.aliases`.
+ * @returns
+ */
+export function applyAllAliasPrefixes(name: string, prefixes: string | string[]): string[] {
+    if (typeof(prefixes) === "string") {
+        // For legacy config compatibility, accept a single string in place of an array of strings:
+        return [prefixes + name];
+    }
+
+    if (prefixes.length === 0) {
+        // It seems undesirable to lose all aliases for a room, so assume this should have been 'no prefix' rather than 'no aliases'.
+        return [name];
+    }
+
+    return prefixes.map(prefix => prefix + name);
+}


### PR DESCRIPTION
This means we can have unprefixed aliases but also prefix them with `2023-` to make clean-up easier.