### PR TITLE
Rehydrate shortly upcoming talks from PentaDb to ensure short-notice changes are picked up

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -198,7 +198,7 @@ export class Scheduler {
                     //     time may slip forward.
                     await this.conference.backend.refreshShortTerm((minVar + 1) * 60);
                 } catch (e) {
-                    LogService.error("Scheduler", `Failed short-term schedule refresh: ${e.message ?? e}`);
+                    LogService.error("Scheduler", `Failed short-term schedule refresh: ${e.message ?? e}\n${e.stack ?? '?'}`);
                 }
 
                 const upcomingTalks = await this.conference.getUpcomingTalkStarts(minVar, minVar);

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -191,6 +191,16 @@ export class Scheduler {
             LogService.info("Scheduler", "Scheduling tasks");
             try {
                 const minVar = config.conference.lookaheadMinutes;
+                try {
+                    // Refresh upcoming parts of our schedule to ensure it's really up to date.
+                    // Rationale: Sometimes schedules get changed at short notice, so we try our best to accommodate that.
+                    // Rationale for adding 1 minute: so we don't cut it too close to the wire; whilst processing the refresh,
+                    //     time may slip forward.
+                    await this.conference.backend.refreshShortTerm((minVar + 1) * 60);
+                } catch (e) {
+                    LogService.error("Scheduler", `Failed short-term schedule refresh: ${e.message ?? e}`);
+                }
+
                 const upcomingTalks = await this.conference.getUpcomingTalkStarts(minVar, minVar);
                 const upcomingQA = await this.conference.getUpcomingQAStarts(minVar, minVar);
                 const upcomingEnds = await this.conference.getUpcomingTalkEnds(minVar, minVar);

--- a/src/backends/IScheduleBackend.ts
+++ b/src/backends/IScheduleBackend.ts
@@ -20,6 +20,15 @@ export interface IScheduleBackend {
     refresh(): Promise<void>;
 
     /**
+     * Calling this function requests the schedule backend to look ahead `lookaheadSeconds` seconds into the future
+     * and try its best to ensure whatever talks in that window of time are up-to-date in the backend's view of the schedule.
+     *
+     * This is an ugly hack to support short-notice changes to the conference schedule, as happens in real life.
+     * It is principally expected to be called by the Scheduler when scheduling tasks in the short-term future.
+     */
+    refreshShortTerm(lookaheadSeconds: number): Promise<void>;
+
+    /**
      * Returns true iff the current schedule was loaded from cache, rather than from the intended source.
      * This happens if there was a problem loading the schedule from the intended source for some reason.
      * The intention of exposing this information is that it allows us to send a notice into the

--- a/src/backends/json/JsonScheduleBackend.ts
+++ b/src/backends/json/JsonScheduleBackend.ts
@@ -71,6 +71,12 @@ export class JsonScheduleBackend implements IScheduleBackend {
         this.wasFromCache = false;
     }
 
+    async refreshShortTerm(_lookaheadSeconds: number): Promise<void> {
+        // NOP: There's no way to partially refresh a JSON schedule.
+        // Short-term changes to a JSON schedule are therefore currently unimplemented.
+        // This hack was intended for Penta anyway.
+    }
+
     get conference(): IConference {
         return this.loader.conference;
     };

--- a/src/backends/penta/db/PentaDb.ts
+++ b/src/backends/penta/db/PentaDb.ts
@@ -162,7 +162,6 @@ export class PentaDb {
     }
 
     private postprocessDbTalk(talk: IRawDbTalk): IDbTalk {
-
         const qaStartDatetime = talk.qa_start_datetime + this.config.schedulePreBufferSeconds * 1000;
         let livestreamStartDatetime: number;
         if (talk.prerecorded) {
@@ -185,7 +184,7 @@ export class PentaDb {
     }
 
     private postprocessDbTalks(rows: IRawDbTalk[]): IDbTalk[] {
-        return rows.map(this.postprocessDbTalk);
+        return rows.map(this.postprocessDbTalk.bind(this));
     }
 
     private sanitizeRecords(rows: IDbPerson[]): IDbPerson[] {

--- a/src/backends/penta/db/PentaDb.ts
+++ b/src/backends/penta/db/PentaDb.ts
@@ -116,6 +116,32 @@ export class PentaDb {
     }
 
     /**
+     * Returns a list of database entries for all talks who have some kind of event in the next `lookaheadSeconds` seconds.
+     *
+     * A suggested implementation might be to return all talks overlapping this window, but for now the simple implementation
+     * is just to return talks with a start, end or Q&A start within the time window.
+     *
+     * @param lookaheadMinutes Number of minutes to look ahead into the future.
+     */
+    public async getTalksWithUpcomingEvents(lookaheadMinutes: number): Promise<IDbTalk[]> {
+        const talksStarting = await this.getUpcomingTalkStarts(lookaheadMinutes, lookaheadMinutes);
+        const talksEnding = await this.getUpcomingTalkEnds(lookaheadMinutes, lookaheadMinutes);
+        const talksQaStarting = await this.getUpcomingQAStarts(lookaheadMinutes, lookaheadMinutes);
+        const result: IDbTalk[] = [];
+        const seenTalkIds = new Set();
+
+        for (const talk of talksStarting.concat(talksEnding, talksQaStarting)) {
+            if (seenTalkIds.has(talk.event_id)) {
+                continue;
+            }
+            seenTalkIds.add(talk.event_id);
+            result.push(talk);
+        }
+
+        return result;
+    }
+
+    /**
      * Gets the record for a talk.
      * @param talkId The talk ID.
      * @returns The record for the talk, if it exists; `null` otherwise.


### PR DESCRIPTION
...also hydrate start and end times so that we can observe the current time shift, which affects the DB but not the XML.

Slightly unpleasant but mostly commit-by-commit review.