### PR TITLE
Fix IRC invite bug

### DIFF
--- a/src/IRCBridge.ts
+++ b/src/IRCBridge.ts
@@ -122,7 +122,7 @@ export class IRCBridge {
 
     public async plumbChannelToRoom(channel: string, roomId: string) {
         if (await this.shouldInviteBot(roomId)) {
-            await this.ircClient.join(channel);
+            await this.mxClient.inviteUser(this.config.botUserId, roomId);
         }
         await this.ircClient.join(channel);
         const result = await this.executeCommand(`plumb ${roomId} ${this.config.serverName} ${channel}`);

--- a/src/IRCBridge.ts
+++ b/src/IRCBridge.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixClient, MatrixError, MatrixEvent } from "matrix-bot-sdk";
+import { MatrixClient, MatrixEvent } from "matrix-bot-sdk";
 import * as irc from "irc-upd";
 import { Auditorium } from "./models/Auditorium";
 import { InterestRoom } from "./models/InterestRoom";
@@ -113,7 +113,9 @@ export class IRCBridge {
             const currentMemberState = await this.mxClient.getRoomStateEvent(roomId, 'm.room.member', this.config.botUserId);
             return !['join','invite'].includes(currentMemberState.membership);
         } catch (ex) {
-            return ex instanceof MatrixError && ex.errcode === "M_NOT_FOUND";
+            // return ex instanceof MatrixError && ex.errcode === "M_NOT_FOUND";
+            // MatrixError isn't a thing yet, assume the bot isn't in the room.
+            return true;
         }
     }
 

--- a/src/IRCBridge.ts
+++ b/src/IRCBridge.ts
@@ -113,11 +113,8 @@ export class IRCBridge {
             const currentMemberState = await this.mxClient.getRoomStateEvent(roomId, 'm.room.member', this.config.botUserId);
             return !['join','invite'].includes(currentMemberState.membership);
         } catch (ex) {
-            if (ex instanceof MatrixError && ex.errcode === "M_NOT_FOUND") {
-                return true;
-            }
+            return ex instanceof MatrixError && ex.errcode === "M_NOT_FOUND";
         }
-        return false;
     }
 
     public async plumbChannelToRoom(channel: string, roomId: string) {

--- a/src/IRCBridge.ts
+++ b/src/IRCBridge.ts
@@ -114,7 +114,8 @@ export class IRCBridge {
             return !['join','invite'].includes(currentMemberState.membership);
         } catch (ex) {
             // return ex instanceof MatrixError && ex.errcode === "M_NOT_FOUND";
-            // MatrixError isn't a thing yet, assume the bot isn't in the room.
+            // MatrixError requires a newer version of the SDK (https://github.com/matrix-org/conference-bot/pull/163).
+            // Assume the bot isn't in the room.
             return true;
         }
     }


### PR DESCRIPTION
This fixes the problem where trying to bridge a room (from previous years) into a channel will break if the IRC bot is already in the room.