### PR TITLE
Use node slim for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:18-slim AS builder
 
 COPY ./ /app/
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN yarn install
 ENV NODE_ENV=production
 RUN yarn build
 
-FROM node:18-alpine
+FROM node:18-slim
 
 COPY --from=builder /app/lib /app/lib
 COPY --from=builder /app/srv /app/srv


### PR DESCRIPTION
Alpine doesn't work with our matrix-bot-sdk version, as the rust-sdk native component doesn't work with it. I'm not a *massive* fan of alpine builds anyway, because are a bit funny over glibc-type stuff. This solves our problem, so let's just use slimmed down debian.