### PR TITLE
Drop querystring in favor of URLSearch params

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run Homerunner tests
         timeout-minutes: 10
         env:
-          HOMERUNNER_IMAGE: ghcr.io/matrix-org/synapse/complement-synapse:latest
+          HOMERUNNER_IMAGE: ghcr.io/element-hq/synapse/complement-synapse:latest
           HOMERUNNER_SPAWN_HS_TIMEOUT_SECS: 100
           NODE_OPTIONS: --dns-result-order ipv4first
         run: |

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "node-fetch": "^2.6.1",
     "pg": "^8.9.0",
     "postcss-preset-env": "^6.7.0",
-    "querystring-es3": "^0.2.1",
     "prom-client": "^15.0.0",
     "qs": "^6.11.2",
     "rfc4648": "^1.4.0",

--- a/web/widgets.ts
+++ b/web/widgets.ts
@@ -14,11 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as qs from 'qs';
-
 export const urlParams = (new URL(window.location.href)).searchParams;
 export const widgetId = urlParams.get("widgetId");
 export const isWidget = widgetId && widgetId !== "$matrix_widget_id";
 
-const widgetQuery = qs.parse(window.location.hash.substring(1));
-export const addlQuery = Object.assign({}, qs.parse(window.location.search.substring(1)), widgetQuery);
+const widgetparams = new URLSearchParams(window.location.hash.substring(1))
+const widgetQuery = {}
+for (const entry of widgetparams.entries()) {
+    widgetQuery[entry[0]] = entry[1]
+}
+
+const searchParams = new URLSearchParams(window.location.search.substring(1))
+const parsedSearch = {}
+for (const entry of searchParams.entries()) {
+    parsedSearch[entry[0]] = entry[1]
+}
+export const addlQuery = Object.assign({}, parsedSearch, widgetQuery);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,8 +49,7 @@ module.exports = {
         ],
     },
     resolve: {
-        extensions: ['.ts', '.js'],
-        fallback: { "querystring": require.resolve("querystring-es3") }
+        extensions: ['.ts', '.js']
     },
     plugins: [
         new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,11 +4906,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
-querystring-es3@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
-  integrity sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==
-
 railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"


### PR DESCRIPTION
Per the discussion at https://github.com/matrix-org/conference-bot/pull/202#discussion_r1407046517, drop `querystring` in favor of using `URLSearchParams`.