### PR TITLE
Fix last run metric being wrong

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run Homerunner tests
         timeout-minutes: 10
         env:
-          HOMERUNNER_IMAGE: ghcr.io/matrix-org/synapse/complement-synapse:latest
+          HOMERUNNER_IMAGE: ghcr.io/element-hq/synapse/complement-synapse:latest
           HOMERUNNER_SPAWN_HS_TIMEOUT_SECS: 100
           NODE_OPTIONS: --dns-result-order ipv4first
         run: |

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -27,9 +27,9 @@ import { Talk } from "./models/Talk";
 import { CheckInMap } from "./CheckInMap";
 import { ConferenceMatrixClient } from "./ConferenceMatrixClient";
 import { IConfig } from "./config";
-import { Counter } from "prom-client";
+import { Gauge } from "prom-client";
 
-const matrixIdentityApiCallsFailed = new Counter({ name: "confbot_scheduler_last_run", help: "The last time the Scheduler ran its tasks."});
+const schedulerLastRunGauge = new Gauge({ name: "confbot_scheduler_last_run", help: "The last time the Scheduler ran its tasks."});
 
 export enum ScheduledTaskType {
     TalkStart = "talk_start",
@@ -196,7 +196,7 @@ export class Scheduler {
     private async runTasks() {
         try {
             const now = (new Date()).getTime();
-            matrixIdentityApiCallsFailed.inc(now);
+            schedulerLastRunGauge.set(now);
             await this.lock.acquireAsync();
             LogService.info("Scheduler", "Scheduling tasks");
             try {


### PR DESCRIPTION
Wrong variable, wrong type. It was incrementing by the current epoch every time this ran, so basically useless!