### PR TITLE
Support extended room names

### DIFF
--- a/src/commands/HelpCommand.ts
+++ b/src/commands/HelpCommand.ts
@@ -45,12 +45,12 @@ export class HelpCommand implements ICommand {
             "</code></pre>" +
             "<h4>People management:</h4>" +
             "<pre><code>" +
-            "!conference verify &lt;aud&gt;  - Dumps information about who would be invited to which rooms when\n" +
-            "                            the invite command is run for the auditorium.\n" +
-            "!conference invite [aud]  - Issues invites to all the people to their relevant rooms. If an [aud] is\n" +
-            "                            supplied, only that auditorium will receive invites.\n" +
-            "!conference permissions   - Updates moderator status for everyone that is supposed to have it.\n" +
-            "!conference attendance    - Checks the status of invites across the conference.\n" +
+            "!conference verify &lt;aud&gt; [backstage]     - Dumps information about who would be invited to which rooms when\n" +
+            "                                             the invite command is run for the auditorium.\n" +
+            "!conference invite [aud]                   - Issues invites to all the people to their relevant rooms. If an [aud] is\n" +
+            "                                             supplied, only that auditorium will receive invites.\n" +
+            "!conference permissions                    - Updates moderator status for everyone that is supposed to have it.\n" +
+            "!conference attendance                     - Checks the status of invites across the conference.\n" +
             "</code></pre>" +
             "<h4>Bridge management:</h4>" +
             "<pre><code>" +

--- a/src/commands/RunCommand.ts
+++ b/src/commands/RunCommand.ts
@@ -25,7 +25,7 @@ export class RunCommand implements ICommand {
     constructor(private readonly client: MatrixClient, private readonly conference: Conference, private readonly scheduler: Scheduler) {}
 
     public async run(roomId: string, event: any, args: string[]) {
-        const audId = args[0];
+        const audId = args.join(" ");
         if (audId === "all") {
             await this.scheduler.addAuditorium("all");
         } else {

--- a/src/commands/VerifyCommand.ts
+++ b/src/commands/VerifyCommand.ts
@@ -29,8 +29,18 @@ export class VerifyCommand implements ICommand {
     constructor(private readonly client: MatrixClient, private readonly conference: Conference) {}
 
     public async run(roomId: string, event: any, args: string[]) {
-        const audId = args[0];
+        let audId;
+        if (args.includes("backstage")) {
+            const aud_slice = args.slice(0, -1)
+            audId = aud_slice.join(" ")
+        }
+        else {
+            audId = args.join(" ");
+        }
 
+        console.log(audId)
+        const auds = this.conference.storedAuditoriums
+        console.dir(auds)
         let aud: PhysicalRoom = this.conference.getAuditorium(audId);
         if (args.includes("backstage")) {
             aud = this.conference.getAuditoriumBackstage(audId);

--- a/src/commands/VerifyCommand.ts
+++ b/src/commands/VerifyCommand.ts
@@ -30,7 +30,8 @@ export class VerifyCommand implements ICommand {
 
     public async run(roomId: string, event: any, args: string[]) {
         let audId;
-        if (args.includes("backstage")) {
+        let backstage = args.includes("backstage")
+        if (backstage) {
             const aud_slice = args.slice(0, -1)
             audId = aud_slice.join(" ")
         }
@@ -38,11 +39,8 @@ export class VerifyCommand implements ICommand {
             audId = args.join(" ");
         }
 
-        console.log(audId)
-        const auds = this.conference.storedAuditoriums
-        console.dir(auds)
         let aud: PhysicalRoom = this.conference.getAuditorium(audId);
-        if (args.includes("backstage")) {
+        if (backstage) {
             aud = this.conference.getAuditoriumBackstage(audId);
         }
 

--- a/src/commands/actions/roles.ts
+++ b/src/commands/actions/roles.ts
@@ -24,9 +24,10 @@ export async function runRoleCommand(action: IAction, conference: Conference, cl
     const skipTalks = args.includes("notalks");
 
     if (args[0] && args[0] !== "backstage") {
-        const aud = backstageOnly ? conference.getAuditoriumBackstage(args[0]) : conference.getAuditorium(args[0]);
+        const audId = args.join(" ")
+        const aud = backstageOnly ? conference.getAuditoriumBackstage(audId) : conference.getAuditorium(audId);
         if (!aud) {
-            const spiRoom = conference.getInterestRoom(args[0]);
+            const spiRoom = conference.getInterestRoom(audId);
             if (!spiRoom) return client.replyNotice(roomId, event, "Unknown auditorium/interest room");
             await doInterestResolveAction(action, client, spiRoom, conference, isInvite);
         } else {


### PR DESCRIPTION
The fosdem schedule has a number of rooms with more than word, ie "K.1.105 (La Fontaine)" or "H.1302 (Depage)" and some of the commands were splitting the input args such that the second part of the name was being cut, meaning that the commands were unable to find the rooms. 

This PR adds support for rooms with more than one word in them by changing how the args are parsed when the commands are run. 

The other option for fixing this would be to strip all the rooms as they are parsed/stored - I considered that as well but this seemed faster - happy to change course if it's incorrect. 