### PR TITLE
Add prometheus metric for attendee numbers

### DIFF
--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -91,7 +91,7 @@ export class Conference {
         [personId: string]: IPerson;
     } = {};
 
-    private membersInRooms: Record<string, string[]>;
+    private membersInRooms: Record<string, string[]> = {};
 
     private memberRecalculationPromise = Promise.resolve();
     private membershipRecalculationQueue: string[] = [];

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -906,12 +906,8 @@ export class Conference {
      * @returns A promise that resolves when the call has been made.
      */
     private async enqueueRecalculateRoomMembership(roomId: string) {
-        if (this.membershipRecalculationQueue.has(roomId)) {
-            return;
-        }
-
-        // Not interested in this room.
-        if (!this.membersInRooms[roomId]) {
+        // We are already expecting to process this room OR are not interested in this room.
+        if (this.membershipRecalculationQueue.has(roomId) || !this.membersInRooms[roomId]) {
             return;
         }
 


### PR DESCRIPTION
This scrapes all membership across rooms that map to the current conference, and gives a number for the total number of unique users. We update this when membership changes happen, but in a linear fashion to prevent slowing down the bot too much.