### PR TITLE
Update auditorium names to be the track name on talk start

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -379,6 +379,16 @@ export class Scheduler {
                 (task.talk.qa_startTime !== null ? `<p>During the talk, you can ask questions here for the Q&A at the end. ` +
                 `The questions with the most 👍 votes are most visible to the speaker.</p>` : ''),
             );
+
+            try {
+                const nameEventContent = await this.client.getRoomStateEvent(confAud.roomId, "m.room.name", "");
+                if (task.talk.track != '' && task.talk.track != undefined && task.talk.track != nameEventContent["name"]) {
+                    nameEventContent["name"] = task.talk.track;
+                    await this.client.sendStateEvent(confAud.roomId, "m.room.name", "", nameEventContent);
+                }
+            } catch (e) {
+                LogService.error("Scheduler:talkStart", `Error when considering changing name of track room: ${e}`);
+            }
         } else if (task.type === ScheduledTaskType.TalkQA) {
             if (!task.talk.prerecorded) return;
             if (confTalk !== undefined) {

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -381,10 +381,12 @@ export class Scheduler {
             );
 
             try {
-                const nameEventContent = await this.client.getRoomStateEvent(confAud.roomId, "m.room.name", "");
-                if (task.talk.track != '' && task.talk.track != undefined && task.talk.track != nameEventContent["name"]) {
-                    nameEventContent["name"] = task.talk.track;
-                    await this.client.sendStateEvent(confAud.roomId, "m.room.name", "", nameEventContent);
+                if (task.talk.track != '' && task.talk.track != undefined) {
+                    const nameEventContent = await this.client.getRoomStateEvent(confAud.roomId, "m.room.name", "");
+                    if (task.talk.track != nameEventContent["name"]) {
+                        nameEventContent["name"] = task.talk.track;
+                        await this.client.sendStateEvent(confAud.roomId, "m.room.name", "", nameEventContent);
+                    }
                 }
             } catch (e) {
                 LogService.error("Scheduler:talkStart", `Error when considering changing name of track room`, e);

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -387,7 +387,7 @@ export class Scheduler {
                     await this.client.sendStateEvent(confAud.roomId, "m.room.name", "", nameEventContent);
                 }
             } catch (e) {
-                LogService.error("Scheduler:talkStart", `Error when considering changing name of track room: ${e}`);
+                LogService.error("Scheduler:talkStart", `Error when considering changing name of track room`, e);
             }
         } else if (task.type === ScheduledTaskType.TalkQA) {
             if (!task.talk.prerecorded) return;


### PR DESCRIPTION
pulled from FOSDEM 2024 Hotfixes #228 

A nice-to-have would be to update on Sunday before the first talk even starts (and maybe slightly in advance of the changeover halfway through the day too).

But that would have been complicated to do and we needed something simple and robust on the day.