### PR TITLE
For support room invites, fix multiple-role people not being invited

### DIFF
--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -747,14 +747,13 @@ export class Conference {
         return [];
     }
 
-    public async getInviteTargetsForAuditorium(auditorium: Auditorium, backstage = false): Promise<IPerson[]> {
+    public async getInviteTargetsForAuditorium(auditorium: Auditorium, roles = [Role.Coordinator, Role.Host, Role.Speaker]): Promise<IPerson[]> {
         const people = await this.getPeopleForAuditorium(auditorium);
-        const roles = [Role.Coordinator, Role.Host, Role.Speaker];
 
         // HACK dedupe people by name.
         const namesToPersons: Map<string, IPerson> = new Map();
 
-        let shouldWritePerson = (person) => {
+        let shouldWritePerson = (person: IPerson) => {
             // ignore unknown roles
             if (! roles.includes(person.role)) return false;
 

--- a/src/commands/AttendanceCommand.ts
+++ b/src/commands/AttendanceCommand.ts
@@ -88,7 +88,7 @@ export class AttendanceCommand implements ICommand {
             const doAppend = !!targetAudId && (targetAudId === "all" || targetAudId === await auditorium.getId());
             const bs = this.conference.getAuditoriumBackstage(await auditorium.getId());
             const inviteTargets = await this.conference.getInviteTargetsForAuditorium(auditorium);
-            const bsInviteTargets = await this.conference.getInviteTargetsForAuditorium(auditorium, true);
+            const bsInviteTargets = await this.conference.getInviteTargetsForAuditorium(auditorium);
             try {
                 await append(inviteTargets, bsInviteTargets, await auditorium.getId(), auditorium.roomId, bs.roomId, doAppend);
             }

--- a/src/commands/DevCommand.ts
+++ b/src/commands/DevCommand.ts
@@ -27,7 +27,7 @@ export class DevCommand implements ICommand {
     public async run(roomId: string, event: any, args: string[]) {
         let people: IPerson[] = [];
         for (const aud of this.conference.storedAuditoriums) {
-            const inviteTargets = await this.conference.getInviteTargetsForAuditorium(aud, true);
+            const inviteTargets = await this.conference.getInviteTargetsForAuditorium(aud);
             people.push(...inviteTargets.filter(i => i.role === Role.Coordinator));
         }
         const newPeople: IPerson[] = [];

--- a/src/commands/InviteCommand.ts
+++ b/src/commands/InviteCommand.ts
@@ -54,9 +54,8 @@ export class InviteCommand implements ICommand {
         if (args[0] && args[0] === "speakers-support") {
             let people: IPerson[] = [];
             for (const aud of this.conference.storedAuditoriumBackstages) {
-                people.push(...await this.conference.getInviteTargetsForAuditorium(aud, true));
+                people.push(...await this.conference.getInviteTargetsForAuditorium(aud, [Role.Speaker]));
             }
-            people = people.filter(p => p.role === Role.Speaker);
             const newPeople: IPerson[] = [];
             people.forEach(p => {
                 if (!newPeople.some(n => n.id === p.id)) {
@@ -75,8 +74,8 @@ export class InviteCommand implements ICommand {
                 //     continue;
                 // }
 
-                const inviteTargets = await this.conference.getInviteTargetsForAuditorium(aud, true);
-                people.push(...inviteTargets.filter(i => i.role === Role.Coordinator));
+                const inviteTargets = await this.conference.getInviteTargetsForAuditorium(aud, [Role.Coordinator]);
+                people.push(...inviteTargets);
             }
             const newPeople: IPerson[] = [];
             people.forEach(p => {

--- a/src/commands/VerifyCommand.ts
+++ b/src/commands/VerifyCommand.ts
@@ -68,7 +68,7 @@ export class VerifyCommand implements ICommand {
 
         if (aud instanceof Auditorium) {
             audToInvite = await this.conference.getInviteTargetsForAuditorium(aud);
-            audBackstageToInvite = await this.conference.getInviteTargetsForAuditorium(aud, true);
+            audBackstageToInvite = await this.conference.getInviteTargetsForAuditorium(aud);
             audToMod = await this.conference.getModeratorsForAuditorium(aud);
         } else if (aud instanceof InterestRoom) {
             audToInvite = await this.conference.getInviteTargetsForInterest(aud);

--- a/src/commands/actions/people.ts
+++ b/src/commands/actions/people.ts
@@ -40,7 +40,7 @@ export async function doAuditoriumResolveAction(
     // We know that everyone should be in the backstage room, so resolve that list of people
     // to make the identity server lookup efficient.
     const backstagePeople = isInvite
-        ? await conference.getInviteTargetsForAuditorium(aud, true)
+        ? await conference.getInviteTargetsForAuditorium(aud)
         : await conference.getModeratorsForAuditorium(aud);
     LogService.info("backstagePeople", `${backstagePeople}`);
     const resolvedBackstagePeople = await resolveIdentifiers(client, backstagePeople);
@@ -50,7 +50,7 @@ export async function doAuditoriumResolveAction(
 
     const allPossiblePeople = isInvite
         ? resolvedBackstagePeople
-        : await resolveIdentifiers(client, await conference.getInviteTargetsForAuditorium(aud, true));
+        : await resolveIdentifiers(client, await conference.getInviteTargetsForAuditorium(aud));
 
     await action(client, backstage.roomId, resolvedBackstagePeople);
 


### PR DESCRIPTION
Pulled out of FOSDEM 2024 hotfixes #228


Two things here:

- in the general case, we make it so that the Coordinator trumps Speaker. This at least makes it a little more deterministic when there's a conflict, but I think we ought to consider supporting multiple role people a bit more natively/robustly in the future. (but at short-notice, this would have been too error-prone to do)
- for the support room invite case, we fix dual-role wielders not being invited to the right room, by applying the correct filtering at the source to avoid role conflicts messing stuff up.
