### PR TITLE
Allow configuration of multiple moderator users to be invited to all rooms.

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -26,10 +26,10 @@ idServerDomain: "vector.im"
 # result in emails or other communications to the user.
 idServerBrand: "vector-im"
 
-# This is the user ID of the moderator for all public-facing rooms the bot creates.
-# Note that this user will be granted power level 100 (the highest) in every room
+# These are the user IDs of the moderators for all public-facing rooms the bot creates.
+# Note that these users will be granted power level 100 (the highest) in every room
 # and be invited.
-moderatorUserId: "@moderator:example.org"
+moderatorUserIds: ["@moderator:example.org"]
 
 # Settings for how the bot should represent livestreams.
 livestream:

--- a/spec/basic.spec.ts
+++ b/spec/basic.spec.ts
@@ -1,49 +1,146 @@
 import { E2ESetupTestTimeout, E2ETestEnv } from "./util/e2e-test";
 import { describe, it, beforeEach, afterEach, expect } from "@jest/globals";
 
-describe('Basic test setup', () => {
-    let testEnv: E2ETestEnv;
-    beforeEach(async () => {
-        testEnv = await E2ETestEnv.createTestEnv({
-            fixture: 'basic-conference',
-        });
-        const welcomeMsg = testEnv.waitForMessage();
-        await testEnv.setUp();
-        console.log((await welcomeMsg).event.content.body.startsWith('WECOME!'));
-    }, E2ESetupTestTimeout);
-    afterEach(() => {
-        return testEnv?.tearDown();
-    });
-    it('should start up successfully', async () => {
-        const { event } = await testEnv.sendAdminCommand('!conference status');
-        console.log(event.content.body);
-        // Check that we're generally okay.
-        expect(event.content.body).toMatch('Scheduled tasks yet to run: 0');
-        expect(event.content.body).toMatch('Schedule source healthy: true');
-    });
-    it('should be able to build successfully', async () => {
-        let spaceBuilt, supportRoomsBuilt, conferenceBuilt = false;
-        const waitForFinish = new Promise<void>((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error(
-                `Build incomplete. spaceBuild: ${spaceBuilt}, supportRoomsBuilt: ${supportRoomsBuilt}, conferenceBuilt: ${conferenceBuilt}`
-            )), 30000);
-            testEnv.adminClient.on('room.message', (_, event) => {
-                if (event.content.body.includes("Your conference's space is at")) {
-                    spaceBuilt = true;
-                } else if (event.content.body.includes("Support rooms have been created")) {
-                    supportRoomsBuilt = true;
-                } else if (event.content.body.includes("CONFERENCE BUILT")) {
-                    conferenceBuilt = true;
-                }
+async function buildConference(testEnv: E2ETestEnv): Promise<void> {
+  let spaceBuilt,
+    supportRoomsBuilt,
+    conferenceBuilt = false;
+  const waitForFinish = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `Build incomplete. spaceBuild: ${spaceBuilt}, supportRoomsBuilt: ${supportRoomsBuilt}, conferenceBuilt: ${conferenceBuilt}`
+          )
+        ),
+      30000
+    );
+    testEnv.adminClient.on("room.message", (_, event) => {
+      if (event.content.body.includes("Your conference's space is at")) {
+        spaceBuilt = true;
+      } else if (
+        event.content.body.includes("Support rooms have been created")
+      ) {
+        supportRoomsBuilt = true;
+      } else if (event.content.body.includes("CONFERENCE BUILT")) {
+        conferenceBuilt = true;
+      }
 
-                if (spaceBuilt && supportRoomsBuilt && conferenceBuilt) {
-                    resolve();
-                    clearTimeout(timeout);
-                }
-            })
-        });
-        await testEnv.sendAdminCommand('!conference build');
-        await waitForFinish;
-        // TODO: Now test that all the expected rooms are there.
+      if (spaceBuilt && supportRoomsBuilt && conferenceBuilt) {
+        resolve();
+        clearTimeout(timeout);
+      }
     });
+  });
+  await testEnv.sendAdminCommand("!conference build");
+  await waitForFinish;
+}
+
+function describeLocator(locator: any): string {
+  let out = `(${locator.conferenceId}) ${locator.kind}`;
+  for (let key of Object.keys(locator).sort()) {
+    if (key !== "conferenceId" && key !== "kind") {
+      out += ` ${key}=${locator[key]}`;
+    }
+  }
+  return out;
+}
+
+describe("Basic test setup", () => {
+  let testEnv: E2ETestEnv;
+  beforeEach(async () => {
+    testEnv = await E2ETestEnv.createTestEnv({
+      fixture: "basic-conference",
+    });
+    const welcomeMsg = testEnv.waitForMessage();
+    await testEnv.setUp();
+    console.log((await welcomeMsg).event.content.body.startsWith("WECOME!"));
+  }, E2ESetupTestTimeout);
+  afterEach(() => {
+    return testEnv?.tearDown();
+  });
+  it("should start up successfully", async () => {
+    const { event } = await testEnv.sendAdminCommand("!conference status");
+    console.log(event.content.body);
+    // Check that we're generally okay.
+    expect(event.content.body).toMatch("Scheduled tasks yet to run: 0");
+    expect(event.content.body).toMatch("Schedule source healthy: true");
+  });
+  it("should be able to build successfully", async () => {
+    await buildConference(testEnv);
+
+    // Now test that all the expected rooms are there.
+    // We will match against the 'locator' state events to identify the rooms.
+
+    const joinedRoomIds = await testEnv.confbotClient.getJoinedRooms();
+    console.debug("joined room IDs: ", joinedRoomIds);
+
+    const allLocators: string[] = [];
+    let roomsWithoutLocators = 0;
+
+    for (const joinedRoomId of joinedRoomIds) {
+      if (joinedRoomId == testEnv.opts.config?.managementRoom) {
+        // The management room is not interesting
+        continue;
+      }
+      try {
+        const roomLocator = await testEnv.confbotClient.getRoomStateEvent(
+          joinedRoomId,
+          "org.matrix.confbot.locator",
+          ""
+        );
+        allLocators.push(describeLocator(roomLocator));
+      } catch (error) {
+        // This room doesn't have a locator
+        console.warn("room without locator: ", joinedRoomId);
+        roomsWithoutLocators += 1;
+      }
+    }
+
+    expect(allLocators.sort()).toMatchInlineSnapshot(`
+      [
+        "(test-conf) auditorium auditoriumId=main_stream",
+        "(test-conf) auditorium_backstage auditoriumId=main_stream",
+        "(test-conf) conference",
+        "(test-conf) conference_space",
+        "(test-conf) talk talkId=1",
+      ]
+    `);
+    // TODO understand/explain why there are 6 rooms without locators
+    expect(roomsWithoutLocators).toBe(6);
+  });
+
+  it("should invite the moderator users to relevant rooms", async () => {
+    await buildConference(testEnv);
+
+    // List of rooms that we expect the moderator user to be invited to
+    const rooms = [
+      // `#test-conf:${testEnv.homeserver.domain}`, -- not invited to the root space
+      `#main_stream:${testEnv.homeserver.domain}`,
+      // `#main_stream-backstage:${testEnv.homeserver.domain}` -- not invited to the backstage,
+      `#talk-1:${testEnv.homeserver.domain}`,
+    ];
+    const moderatorUserId = `@modbot:${testEnv.homeserver.domain}`;
+
+    for (let roomAlias of rooms) {
+      const roomId = await testEnv.confbotClient.resolveRoom(roomAlias);
+      let moderatorMembershipInRoom: any;
+      try {
+        moderatorMembershipInRoom =
+          await testEnv.confbotClient.getRoomStateEvent(
+            roomId,
+            "m.room.member",
+            moderatorUserId
+          );
+      } catch (err) {
+        const state = JSON.stringify(
+          await testEnv.confbotClient.getRoomState(roomId)
+        );
+        throw new Error(
+          `No m.room.member for ${moderatorUserId} in ${roomId} (${roomAlias}): ${state}`
+        );
+      }
+      expect(moderatorMembershipInRoom.membership).toBe("invite");
+    }
+  });
 });

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -227,13 +227,14 @@ export class E2ETestEnv {
             ...providedConfig,
         };
         const conferenceBot = await ConferenceBot.start(config);
-        return new E2ETestEnv(homeserver, conferenceBot, adminUser.client, opts, tmpDir, config);
+        return new E2ETestEnv(homeserver, conferenceBot, adminUser.client, confBotOpts.client, opts, tmpDir, config);
     }
 
     private constructor(
         public readonly homeserver: ComplementHomeServer,
         public confBot: ConferenceBot,
         public readonly adminClient: MatrixClient,
+        public readonly confbotClient: MatrixClient,
         public readonly opts: Opts,
         private readonly dataDir: string,
         private readonly config: IConfig,

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -203,7 +203,7 @@ export class E2ETestEnv {
                     }
                 },
             },
-            moderatorUserId: `@modbot:${homeserver.domain}`,
+            moderatorUserIds: [`@modbot:${homeserver.domain}`],
             webserver: {
                 address: '0.0.0.0',
                 port: 0,

--- a/src/Conference.ts
+++ b/src/Conference.ts
@@ -394,7 +394,7 @@ export class Conference {
                         this.client,
                         mergeWithCreationTemplate(AUDITORIUM_BACKSTAGE_CREATION_TEMPLATE, {
                             room_alias_name: (new RoomAlias(alias)).localpart,
-                            invite: [this.config.moderatorUserId],
+                            invite: this.config.moderatorUserIds,
                         }),
                     );
                     await rootSpace.addChildRoom(roomId);
@@ -433,7 +433,7 @@ export class Conference {
             subspace = await this.client.createSpace({
                 isPublic: true,
                 name: name,
-                invites: [this.config.moderatorUserId],
+                invites: this.config.moderatorUserIds,
             });
             this.subspaces[subspaceId] = subspace;
 
@@ -448,9 +448,11 @@ export class Conference {
                 roomId: subspace.roomId,
             } as IStoredSubspace);
 
-            // Grants PL100 to the moderator in the subspace.
+            // Grants PL100 to the moderators in the subspace.
             // We can't do this directly with `createSpace` unfortunately, as we could for plain rooms.
-            await this.client.setUserPowerLevel(this.config.moderatorUserId, subspace.roomId, 100);
+            for (let moderator of this.config.moderatorUserIds) {
+                await this.client.setUserPowerLevel(moderator, subspace.roomId, 100);
+            }
         } else {
             subspace = this.subspaces[subspaceId];
         }
@@ -481,7 +483,7 @@ export class Conference {
                 );
             } else {
                 // Create a new interest room.
-                roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(SPECIAL_INTEREST_CREATION_TEMPLATE(this.config.moderatorUserId), {
+                roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(SPECIAL_INTEREST_CREATION_TEMPLATE(this.config.moderatorUserIds), {
                     creation_content: {
                         [RSC_CONFERENCE_ID]: this.id,
                         [RSC_SPECIAL_INTEREST_ID]: interestRoom.id,
@@ -571,7 +573,7 @@ export class Conference {
 
         await parentSpace.addChildSpace(audSpace, { order: `auditorium-${auditorium.id}` });
 
-        const roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(AUDITORIUM_CREATION_TEMPLATE(this.config.moderatorUserId), {
+        const roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(AUDITORIUM_CREATION_TEMPLATE(this.config.moderatorUserIds), {
             creation_content: {
                 [RSC_CONFERENCE_ID]: this.id,
                 [RSC_AUDITORIUM_ID]: auditorium.id,
@@ -629,7 +631,7 @@ export class Conference {
         }
 
         if (!this.talks[talk.id]) {
-            roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(TALK_CREATION_TEMPLATE(this.config.moderatorUserId), {
+            roomId = await safeCreateRoom(this.client, mergeWithCreationTemplate(TALK_CREATION_TEMPLATE(this.config.moderatorUserIds), {
                 name: talk.title,
                 creation_content: {
                     [RSC_CONFERENCE_ID]: this.id,
@@ -848,7 +850,9 @@ export class Conference {
         // we'll be unable to do promotions/demotions in the future.
         const pls = await this.client.getRoomStateEvent(roomId, "m.room.power_levels", "");
         pls['users'][await this.client.getUserId()] = 100;
-        pls['users'][this.config.moderatorUserId] = 100;
+        for (let moderator of this.config.moderatorUserIds) {
+            pls['users'][moderator] = 100;
+        }
         for (const userId of mxids) {
             if (pls['users'][userId]) continue;
             pls['users'][userId] = 50;
@@ -916,7 +920,9 @@ export class Conference {
             this.membersInRooms[roomId] = joinedOrLeftMembers;
             const total = new Set(Object.values(this.membersInRooms).flat());
             total.delete(myUserId);
-            total.delete(this.config.moderatorUserId);
+            for (let moderator of this.config.moderatorUserIds) {
+                total.delete(moderator);
+            }
             attendeeTotalGauge.set(total.size);
         } catch (ex) {
             LogService.warn("Conference", `Failed to recalculate room membership for ${roomId}`, ex);

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,11 @@ export interface IConfig {
     managementRoom: string;
     idServerDomain?: string;
     idServerBrand?: string;
+
+    // Legacy option that causes a startup error when supplied.
+    // Removed in favour of `moderatorUserIds`.
+    moderatorUserId?: string;
+    
     moderatorUserIds: string[];
     livestream: {
         auditoriumUrl: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export interface IConfig {
     managementRoom: string;
     idServerDomain?: string;
     idServerBrand?: string;
-    moderatorUserId: string;
+    moderatorUserIds: string[];
     livestream: {
         auditoriumUrl: string;
         talkUrl: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,11 @@ export class ConferenceBot {
         if (!RunMode[config.mode]) {
             throw Error(`Incorrect mode '${config.mode}'`);
         }
+
+        if (config.moderatorUserId !== undefined) {
+            throw new Error("The `moderatorUserId` config option has been replaced by `moderatorUserIds` that takes a list.");
+        }
+        
         const storage = new SimpleFsStorageProvider(path.join(config.dataPath, "bot.json"));
         const client = await ConferenceMatrixClient.create(config, storage);
         client.impersonateUserId(config.userId);       

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -19,7 +19,7 @@ import { RoomCreateOptions } from "matrix-bot-sdk";
 
 export const KickPowerLevel = 50;
 
-export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = (moderatorUserId: string) => ({
+export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = (moderatorUserIds: string[]) => ({
     ban: 50,
     events_default: 0,
     invite: 50,
@@ -40,10 +40,7 @@ export const PUBLIC_ROOM_POWER_LEVELS_TEMPLATE = (moderatorUserId: string) => ({
         "m.space.parent": 100,
         "m.space.child": 100,
     },
-    users: {
-        [moderatorUserId]: 100,
-        // should be populated with the creator
-    },
+    users: Object.fromEntries(moderatorUserIds.map(moderator => [moderator, 100])),
 });
 
 export const PRIVATE_ROOM_POWER_LEVELS_TEMPLATE = {
@@ -91,7 +88,7 @@ export const CONFERENCE_ROOM_CREATION_TEMPLATE: RoomCreateOptions = {
     },
 };
 
-export const AUDITORIUM_CREATION_TEMPLATE = (moderatorUserId: string) => ({
+export const AUDITORIUM_CREATION_TEMPLATE = (moderatorUserIds: string[]) => ({
     preset: 'public_chat',
     visibility: 'public',
     initial_state: [
@@ -101,8 +98,8 @@ export const AUDITORIUM_CREATION_TEMPLATE = (moderatorUserId: string) => ({
     creation_content: {
         [RSC_ROOM_KIND_FLAG]: RoomKind.Auditorium,
     },
-    power_level_content_override: PUBLIC_ROOM_POWER_LEVELS_TEMPLATE(moderatorUserId),
-    invite: [moderatorUserId],
+    power_level_content_override: PUBLIC_ROOM_POWER_LEVELS_TEMPLATE(moderatorUserIds),
+    invite: moderatorUserIds,
 } satisfies RoomCreateOptions);
 
 export const AUDITORIUM_BACKSTAGE_CREATION_TEMPLATE: RoomCreateOptions = {
@@ -118,7 +115,7 @@ export const AUDITORIUM_BACKSTAGE_CREATION_TEMPLATE: RoomCreateOptions = {
     power_level_content_override: PRIVATE_ROOM_POWER_LEVELS_TEMPLATE,
 };
 
-export const TALK_CREATION_TEMPLATE = (moderatorUserId: string) => ({ // before being opened up to the public
+export const TALK_CREATION_TEMPLATE = (moderatorUserIds: string[]) => ({ // before being opened up to the public
     preset: 'private_chat',
     visibility: 'private',
     initial_state: [
@@ -128,11 +125,11 @@ export const TALK_CREATION_TEMPLATE = (moderatorUserId: string) => ({ // before 
     creation_content: {
         [RSC_ROOM_KIND_FLAG]: RoomKind.Talk,
     },
-    power_level_content_override: PUBLIC_ROOM_POWER_LEVELS_TEMPLATE(moderatorUserId),
-    invite: [moderatorUserId],
+    power_level_content_override: PUBLIC_ROOM_POWER_LEVELS_TEMPLATE(moderatorUserIds),
+    invite: moderatorUserIds,
 } satisfies RoomCreateOptions);
 
-export const SPECIAL_INTEREST_CREATION_TEMPLATE = (moderatorUserId: string) => ({
+export const SPECIAL_INTEREST_CREATION_TEMPLATE = (moderatorUserIds: string[]) => ({
     preset: 'public_chat',
     visibility: 'public',
     initial_state: [
@@ -149,7 +146,7 @@ export const SPECIAL_INTEREST_CREATION_TEMPLATE = (moderatorUserId: string) => (
             "m.room.power_levels": 50,
         },
     },
-    invite: [moderatorUserId],
+    invite: moderatorUserIds,
 } satisfies RoomCreateOptions);
 
 export function mergeWithCreationTemplate(template: RoomCreateOptions, addlProps: any): any {

--- a/src/models/room_kinds.ts
+++ b/src/models/room_kinds.ts
@@ -129,25 +129,28 @@ export const TALK_CREATION_TEMPLATE = (moderatorUserIds: string[]) => ({ // befo
     invite: moderatorUserIds,
 } satisfies RoomCreateOptions);
 
-export const SPECIAL_INTEREST_CREATION_TEMPLATE = (moderatorUserIds: string[]) => ({
-    preset: 'public_chat',
-    visibility: 'public',
-    initial_state: [
-        {type: "m.room.guest_access", state_key: "", content: {guest_access: "can_join"}},
-        {type: "m.room.history_visibility", state_key: "", content: {history_visibility: "world_readable"}},
-    ],
-    creation_content: {
-        [RSC_ROOM_KIND_FLAG]: RoomKind.SpecialInterest,
-    },
-    power_level_content_override: {
-        ...PUBLIC_ROOM_POWER_LEVELS_TEMPLATE,
-        events: {
-            ...PUBLIC_ROOM_POWER_LEVELS_TEMPLATE['events'],
-            "m.room.power_levels": 50,
+export const SPECIAL_INTEREST_CREATION_TEMPLATE = (moderatorUserIds: string[]) => {
+    let template = PUBLIC_ROOM_POWER_LEVELS_TEMPLATE(moderatorUserIds);
+    return ({
+        preset: 'public_chat',
+        visibility: 'public',
+        initial_state: [
+            {type: "m.room.guest_access", state_key: "", content: {guest_access: "can_join"}},
+            {type: "m.room.history_visibility", state_key: "", content: {history_visibility: "world_readable"}},
+        ],
+        creation_content: {
+            [RSC_ROOM_KIND_FLAG]: RoomKind.SpecialInterest,
         },
-    },
-    invite: moderatorUserIds,
-} satisfies RoomCreateOptions);
+        power_level_content_override: {
+            ...template,
+            events: {
+                ...template.events,
+                "m.room.power_levels": 50,
+            },
+        },
+        invite: moderatorUserIds,
+    } satisfies RoomCreateOptions);
+};
 
 export function mergeWithCreationTemplate(template: RoomCreateOptions, addlProps: any): any {
     const result = {...template};


### PR DESCRIPTION
We want the ability to invite someone else alongside the moderator bot, in all rooms.

This makes `moderatorUserId` an array instead, `moderatorUserIds` but otherwise the semantics should be all the same?