### PR TITLE
Support `!c` as a command shorthand

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,6 +273,7 @@ export class ConferenceBot {
 
             const prefixes = [
                 "!conference",
+                "!c",
                 localpart + ":",
                 displayName + ":",
                 userId + ":",


### PR DESCRIPTION
`!conference` is just too typo-prone :-)