### PR TITLE
Run the e2e tests with the docker image

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,8 +61,11 @@ jobs:
         with:
           path: conference-bot
       - name: Build test image
+        # Set `build` as the target (rather than default to the final, prune'd
+        # stage), as `build` includes the dev dependencies which are needed for
+        # testing.
         run: |
-          docker build -t conference-bot-test:local ./conference-bot
+          docker build --target build -t conference-bot-test:local ./conference-bot
       # Regression test for https://github.com/matrix-org/conference-bot/pull/264.
       - name: Check the matrix-bot-sdk was built correctly
         run: |


### PR DESCRIPTION
~~I expect this to fail, but worth a quick shot.~~ I guess it works!

Switch to running the tests within our docker image, to ensure that it's built correctly. Requires https://github.com/matrix-org/conference-bot/pull/264.

The first commit was intended to be a regression test for https://github.com/matrix-org/conference-bot/pull/264, but it turns out that running the tests will fix the issue and build the development dependencies :facepalm: 

So I added another commit (https://github.com/matrix-org/conference-bot/pull/265/commits/110066006c792f8e6bf986f6e4e83a916ecd7a61) that will just start the container and try to import matrix-bot-sdk. That should fail until #264 is merged.