### PR TITLE
Remove `dry_run_enabled` config option

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -245,6 +245,3 @@ metrics:
   enabled: false
   port: 8081
   address: 127.0.0.1
-
-# if set to `true` will prevent the conf-bot from sending live invites to email/matrix_ids
-dry_run_enabled: false

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -220,7 +220,6 @@ export class E2ETestEnv {
                 address: '0.0.0.0',
                 port: 0,
             },
-            dry_run_enabled: false,
             ...providedConfig,
         };
         const conferenceBot = await ConferenceBot.start(config);

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,6 @@ export interface IConfig {
         address: string;
         port: number;
     };
-    dry_run_enabled: boolean;
     conference: {
         id: string;
         name: string;


### PR DESCRIPTION
We aren't really using it anymore. Think it made more sense when we had nothing to test against except a real Pentabarf.

Nowadays we have a staging Pretalx setup and should be testing against that.